### PR TITLE
Deploy static bundles on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ after_script: greenkeeper-lockfile-upload
 script:
   - yarn lint
   - yarn test
-  - yarn build
   - yarn jest --coverage --coverageReporters=text-lcov | yarn coveralls
 
 before_deploy: yarn add now # Install Now CLI
@@ -24,14 +23,17 @@ before_deploy: yarn add now # Install Now CLI
 deploy:
   - provider: script # Run a custom deployment script which we will define below
     script:
-      yarn export
-      now --token $NOW_TOKEN --public --static
+      - yarn export
+      - now --token $NOW_TOKEN --public --static
     skip_cleanup: true
     on:
       all_branches: true
       master: false
   - provider: script
-    script: now --token $NOW_TOKEN --public && now alias --token $NOW_TOKEN
+    script:
+      - yarn build
+      - now --token $NOW_TOKEN --public
+      - now alias --token $NOW_TOKEN
     skip_cleanup: true
     on:
       master: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,9 @@ before_deploy: yarn add now # Install Now CLI
 
 deploy:
   - provider: script # Run a custom deployment script which we will define below
-    script: now --token $NOW_TOKEN --public
+    script:
+      yarn export
+      now --token $NOW_TOKEN --public --static
     skip_cleanup: true
     on:
       all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,18 +22,13 @@ before_deploy: yarn add now # Install Now CLI
 
 deploy:
   - provider: script # Run a custom deployment script which we will define below
-    script:
-      - yarn export
-      - now --token $NOW_TOKEN --public --static
+    script: yarn export && now --token $NOW_TOKEN --public --static
     skip_cleanup: true
     on:
       all_branches: true
       master: false
   - provider: script
-    script:
-      - yarn build
-      - now --token $NOW_TOKEN --public
-      - now alias --token $NOW_TOKEN
+    script: yarn build && now --token $NOW_TOKEN --public && now alias --token $NOW_TOKEN
     skip_cleanup: true
     on:
       master: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,18 +17,19 @@ script:
   - yarn lint
   - yarn test
   - yarn jest --coverage --coverageReporters=text-lcov | yarn coveralls
+  - yarn build
 
 before_deploy: yarn add now # Install Now CLI
 
 deploy:
   - provider: script # Run a custom deployment script which we will define below
-    script: yarn export && now --token $NOW_TOKEN --public --static
+    script: yarn export && now --public --static
     skip_cleanup: true
     on:
       all_branches: true
       master: false
   - provider: script
-    script: yarn build && now --token $NOW_TOKEN --public && now alias --token $NOW_TOKEN
+    script: now --token $NOW_TOKEN --public && now alias --token $NOW_TOKEN
     skip_cleanup: true
     on:
       master: true

--- a/now.json
+++ b/now.json
@@ -9,5 +9,12 @@
   "engines": {
     "node": "8.11.3"
   },
+  "files": [
+    ".next",
+    "server",
+    "static",
+    "package.json",
+    "yarn.lock"
+  ],
   "public": true
 }

--- a/now.json
+++ b/now.json
@@ -11,7 +11,6 @@
   },
   "files": [
     ".next",
-    "server",
     "static",
     "package.json",
     "yarn.lock"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "yarn lint:scripts && yarn lint:styles",
     "lint:scripts": "eslint \"**/*.js\"",
     "lint:styles": "stylelint --fix \"**/*.css\"",
+    "now-build": "echo 'Built on Travis CI'",
     "start": "next start",
     "storybook": "start-storybook -s ./static -p 9001 -c .storybook",
     "test": "NODE_ENV=test BABEL_ENV=test jest",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build-storybook": "build-storybook -s ./static -c .storybook -o .storybook-dist",
     "build": "next build",
     "dev": "next",
+    "export": "next export",
     "format": "prettier --write \"**/*.{js,css}\" && eslint --fix \"**/*.js\" && stylelint --fix \"**/*.css\"",
     "lint": "yarn lint:scripts && yarn lint:styles",
     "lint:scripts": "eslint \"**/*.js\"",


### PR DESCRIPTION
# Description of changes
Instead of building full-blown deployments for pull requests, where we're limited to 3 concurrent instances that can sleep, we're going to deploy static builds. They don't have the performance boost that Next's SSR provides, but they're just previews. In exchange, we can have unlimited static previews and they don't sleep.
