### PR TITLE
Stop using `engines` and fix lint error

### DIFF
--- a/components/head.js
+++ b/components/head.js
@@ -39,7 +39,7 @@ function Head({ description, ogImage, title, url }) {
       <meta property="og:image:height" content="630" />
 
       {/* TODO: Download and avoid network request  */}
-      <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i"></link>
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i" />
     </NextHead>
   );
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -74,7 +74,7 @@ module.exports = {
   // A map from regular expressions to module names that allow to stub out resources with a single module
   moduleNameMapper: {
     '\\.(jpg|jpeg|png|gif|svg)$': '<rootDir>/test-utils/mocks/testFileMock.js',
-    '\\.(css)$': 'identity-obj-proxy',
+    '\\.css$': 'identity-obj-proxy',
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader

--- a/now.master.json
+++ b/now.master.json
@@ -6,9 +6,6 @@
       "NODE_ENV": "production"
     }
   },
-  "engines": {
-    "node": "8.11.4"
-  },
   "files": [
     ".next",
     "static",

--- a/package.json
+++ b/package.json
@@ -85,8 +85,5 @@
     "react-testing-library": "^5.0.0",
     "stylelint": "^9.5.0",
     "stylelint-config-standard": "^18.2.0"
-  },
-  "engines": {
-    "node": "8.11.4"
   }
 }


### PR DESCRIPTION
Dropping engines removes a bit of self-documenting code 😞 , but fixes Travis GH integration 💃 

Will just have to dictate node version in `CONTRIBUTING.md`...