### PR TITLE
Prevent theme map overwriting

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,3 +1,3 @@
 > 1%
-last 2 Chrome versions
+last 2 versions
 not ie < 11

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -22,9 +22,6 @@ module.exports = (storybookBaseConfig, configType) => {
         },
       },
       {
-        // Keep in parity with root postcss.config.js until
-        // https://github.com/storybooks/storybook/issues/2455
-        // is resolved
         loader: 'postcss-loader',
         options: {
           plugins: [
@@ -33,7 +30,7 @@ module.exports = (storybookBaseConfig, configType) => {
               exporter: 'js',
               destination: 'common/styles/themeMap.js',
             }),
-            // except no autoprefixer - assuming dev has modern browser to decrease build speed
+            require('autoprefixer')(),
           ],
         },
       },

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,15 +1,7 @@
 /* eslint-disable global-require */
 module.exports = ({ file, options, env }) => {
-  // Keep in parity with ./storybook/webpack.config postcss-loader until
-  // https://github.com/storybooks/storybook/issues/2455
-  // is resolved
-
   const plugins = {
     'postcss-import': { root: file.dirname },
-    'postcss-export-custom-variables': {
-      exporter: 'js',
-      destination: './common/styles/themeMap.js',
-    },
     autoprefixer:
       env === 'production'
         ? {


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
I noticed that when running Storybook and dev simultaneously, themeMap.js would get fried. This PR prevents that issue, and makes Storybook produce output more similarly to prod.

- Use autoprefixer in Storybook to match prod env better
- Update Browserlist
- Drops maintenance comments since configs are truly separated now
