### PR TITLE
Fix <Link> usage and add eslint rule exception

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -59,6 +59,12 @@
       "rules": {
         "react/react-in-jsx-scope": "off"
       }
+    },
+    {
+      "files": ["components/nav.js"],
+      "rules": {
+        "jsx-a11y/anchor-is-valid": "off"
+      }
     }
   ]
 }

--- a/components/nav.js
+++ b/components/nav.js
@@ -6,12 +6,12 @@ function Nav() {
       <ul>
         <li>
           <Link href="/" prefetch>
-            Home
+            <a>Home</a>
           </Link>
         </li>
         <li>
           <Link href="/about" prefetch>
-            About
+            <a>About</a>
           </Link>
         </li>
       </ul>


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
See: https://github.com/zeit/next.js/issues/816
`<Link>` is simply a higher-order component, and `<a>` must be passed as children to act as traditional links.

## Screenshots/GIFs
<!-- Please provide a view into the feature/bugfix if possible-->
<img width="899" alt="screen shot 2018-08-28 at 11 24 47 pm" src="https://user-images.githubusercontent.com/9523719/44769475-98269e80-ab19-11e8-924f-19262d5cf1ab.png">
