### PR TITLE
Convert prepush to precommit

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint:styles": "stylelint \"**/*.css\"",
     "lint": "yarn lint:scripts && yarn lint:styles",
     "now-build": "echo 'Built on Travis CI'",
-    "prepush": "lint-staged && yarn test",
+    "precommit": "lint-staged && yarn test",
     "start": "next start",
     "storybook": "start-storybook -s ./static -p 9001 -c .storybook",
     "test:ci": "NODE_ENV=test BABEL_ENV=test jest --ci --coverage --coverageReporters=text-lcov | yarn coveralls",


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Prepush hook wasn't properly linting/formatting because lint-staged works on staged stuff, not committed stuff (doi).

Precommit hook is a bit heavy, the alternative would be `husky` rc and I don't see support for multiple commands per-file in the same manner that `lint-staged` supports.

It's either pre-commit formatting on only the files changed + all tests

OR

It's pre-push formatting on the entire code-base + all tests

I'll elect for pre-commit 👍 