### PR TITLE
Attempt to get greenkeeper to update lockfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,17 @@ cache:
   directories:
     - "node_modules"
 
-before_install: yarn global add greenkeeper-lockfile@1
+before_install:
+ - yarn global add greenkeeper-lockfile@1
 
-before_script: greenkeeper-lockfile-update
+install:
+  - yarn install --frozen-lockfile --silent
 
-after_script: greenkeeper-lockfile-upload
+before_script:
+ - greenkeeper-lockfile-update
+
+after_script:
+ - greenkeeper-lockfile-upload
 
 script:
   - yarn lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,13 @@ script:
   - yarn test:ci
   - yarn build
 
-# before_deploy: yarn add now # Install Now CLI
-
 deploy:
-  # - provider: script # Run a custom deployment script which we will define below
-  #   script: yarn export && now --token $NOW_TOKEN
-  #   skip_cleanup: true
-  #   on:
-  #     all_branches: true
-  #     master: false
+  - provider: script
+    script: echo 'No build on feature branches. Now deploys static exports automatically.'
+    skip_cleanup: true
+    on:
+      all_branches: true
+      master: false
   - provider: script
     script: yarn add now && now --local-config "./now.master.json" --token $NOW_TOKEN
     skip_cleanup: true


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Greenkeeper doesn't seem to be updating the lockfile with package updates. Perhaps the `script` referred to in Travis' `_script` methods before running tests is actually the provider within the deploy stage?