### PR TITLE
Simplify api utilities and add example for API-consuming page

### DIFF
--- a/common/config/environment.js
+++ b/common/config/environment.js
@@ -1,3 +1,3 @@
-export default {
-  apiUrl: process.env.OC_API_URL || 'https://staging.api.operationcode.org/api/v1',
-};
+export const apiUrl = process.env.OC_API_URL || 'https://api.operationcode.org/api/v1';
+export const facebookKey = process.env.OC_FACEBOOK_KEY;
+export const googleKey = process.env.OC_GOOGLE_KEY;

--- a/common/config/environment.js
+++ b/common/config/environment.js
@@ -1,3 +1,3 @@
-export const apiUrl = process.env.OC_API_URL || 'https://api.operationcode.org/api/v1';
+export const apiUrl = process.env.OC_API_URL || 'https://staging.api.operationcode.org/api/v1';
 export const facebookKey = process.env.OC_FACEBOOK_KEY;
 export const googleKey = process.env.OC_GOOGLE_KEY;

--- a/common/config/environment.js
+++ b/common/config/environment.js
@@ -1,0 +1,3 @@
+export default {
+  apiUrl: process.env.OC_API_URL || 'https://staging.api.operationcode.org/api/v1',
+};

--- a/common/constants/api.js
+++ b/common/constants/api.js
@@ -10,7 +10,7 @@ export const getScholarshipsPromise = () => get('scholarships');
 export const getServicesPromise = () => get('services');
 
 /* POST REQUESTS */
-export const postMentorRequest = ({ language, additionalDetails, mentor, service }) =>
+export const postMentorRequestPromise = ({ language, additionalDetails, mentor, service }) =>
   post('requests', {
     request: {
       details: additionalDetails,
@@ -21,7 +21,7 @@ export const postMentorRequest = ({ language, additionalDetails, mentor, service
   });
 
 /* PATCH REQUESTS */
-export const patchUpdateRequest = ({ request, status, mentor }) =>
+export const patchUpdateMentorRequestPromise = ({ request, status, mentor }) =>
   patch(`requests/${request}`, {
     request: {
       status,

--- a/common/constants/api.js
+++ b/common/constants/api.js
@@ -1,0 +1,30 @@
+import { get, post, patch } from 'common/utils/api-utils';
+
+/* GET REQUESTS */
+export const getCodeSchoolsPromise = () => get('code_schools');
+export const getMentorPromise = id => get(`mentors/${id}`);
+export const getMentorsPromise = () => get('mentors');
+export const getRequestsPromise = () => get('requests');
+export const getScholarshipPromise = id => get(`scholarships/${id}`);
+export const getScholarshipsPromise = () => get('scholarships');
+export const getServicesPromise = () => get('services');
+
+/* POST REQUESTS */
+export const postMentorRequest = ({ language, additionalDetails, mentor, service }) =>
+  post('requests', {
+    request: {
+      details: additionalDetails,
+      language,
+      requested_mentor_id: mentor,
+      service_id: service,
+    },
+  });
+
+/* PATCH REQUESTS */
+export const patchUpdateRequest = ({ request, status, mentor }) =>
+  patch(`requests/${request}`, {
+    request: {
+      status,
+      mentor,
+    },
+  });

--- a/common/utils/api-utils.js
+++ b/common/utils/api-utils.js
@@ -1,68 +1,19 @@
 import axios from 'axios';
-import config from 'config/environment';
+import { apiUrl } from 'common/config/environment';
 import Cookies from 'universal-cookie';
 
-// TODO: Map config from environment
-export const setAuthorizationHeader = () => {
+const setAuthorizationHeader = () => {
   const cookies = new Cookies();
   return { Authorization: `bearer ${cookies.get('token')}` };
 };
 
-function makeGenericGet(endpoint) {
-  const authHeader = setAuthorizationHeader();
-  return axios
-    .get(`${config.backendUrl}/${endpoint}`, { headers: authHeader })
+export const get = endpoint =>
+  axios
+    .get(`${apiUrl}/${endpoint}`, { headers: setAuthorizationHeader() })
     .then(({ data }) => data);
-}
 
-export function postBackend(path, body) {
-  const authHeader = setAuthorizationHeader();
-  return axios.post(`${config.backendUrl}/${path}`, body, { headers: authHeader });
-}
+export const post = (path, body) =>
+  axios.post(`${apiUrl}/${path}`, body, { headers: setAuthorizationHeader() });
 
-export function patchBackend(path, body) {
-  const authHeader = setAuthorizationHeader();
-  return axios.patch(`${config.backendUrl}/${path}`, body, { headers: authHeader });
-}
-
-export const getServices = () => makeGenericGet('services');
-
-export const getMentors = () => makeGenericGet('mentors');
-export const getMentor = id => makeGenericGet(`mentors/${id}`);
-
-export const getRequests = () => makeGenericGet('requests');
-
-export const getScholarships = () => makeGenericGet('scholarships');
-export const getScholarship = id => makeGenericGet(`scholarships/${id}`);
-
-export function postRequest({ language, additionalDetails, mentor, service }) {
-  const authHeader = setAuthorizationHeader();
-
-  return axios.post(
-    `${config.backendUrl}/requests`,
-    {
-      request: {
-        details: additionalDetails,
-        requested_mentor_id: mentor,
-        service_id: service,
-        language,
-      },
-    },
-    { headers: authHeader },
-  );
-}
-
-export function updateRequest({ request, status, mentor }) {
-  const authHeader = setAuthorizationHeader();
-
-  return axios.patch(
-    `${config.backendUrl}/requests/${request}`,
-    {
-      request: {
-        status,
-        mentor,
-      },
-    },
-    { headers: authHeader },
-  );
-}
+export const patch = (path, body) =>
+  axios.patch(`${apiUrl}/${path}`, body, { headers: setAuthorizationHeader() });

--- a/common/utils/api-utils.js
+++ b/common/utils/api-utils.js
@@ -8,9 +8,7 @@ const setAuthorizationHeader = () => {
 };
 
 export const get = endpoint =>
-  axios
-    .get(`${apiUrl}/${endpoint}`, { headers: setAuthorizationHeader() })
-    .then(({ data }) => data);
+  axios.get(`${apiUrl}/${endpoint}`, { headers: setAuthorizationHeader() });
 
 export const post = (path, body) =>
   axios.post(`${apiUrl}/${path}`, body, { headers: setAuthorizationHeader() });

--- a/jest.config.js
+++ b/jest.config.js
@@ -34,6 +34,9 @@ module.exports = {
     '<rootDir>/common/constants',
     '<rootDir>/test-utils',
 
+    // No real logic to test here
+    '<rootDir>/common/utils/api-utils.js',
+
     // Ignore Next.js files
     '<rootDir>/components/head.js',
     '<rootDir>/components/nav.js',

--- a/pages/.eslintrc
+++ b/pages/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "globals": {
+    "React": true
+  }
+}

--- a/pages/code_schools.js
+++ b/pages/code_schools.js
@@ -1,0 +1,51 @@
+import { getCodeSchoolsPromise } from 'common/constants/api';
+import OutboundLink from 'common/components/OutboundLink/OutboundLink';
+import Section from 'common/components/Section/Section';
+
+export default class CodeSchools extends React.Component {
+  state = {
+    schools: [],
+  };
+
+  componentDidMount() {
+    getCodeSchoolsPromise().then(({ data }) => this.setState({ schools: data }));
+  }
+
+  render() {
+    const { state } = this;
+
+    return (
+      <>
+        <Section theme="white" title="Code Schools">
+          <p>
+            Code schools are accelerated learning programs that will prepare you for a career in
+            software development. Each school listed below ranges in length, vary in tuition costs,
+            and in programming languages. Desirable from an employer&apos;s standpoint, code schools
+            are founded by software developers who saw a need for more programmers and aspired to
+            teach the next generation. We encourage you to check out the schools below, do your
+            research, and ask fellow techies in our Slack Community.
+          </p>
+
+          <aside style={{ textAlign: 'center' }}>
+            <h6>Would you like your school listed here?</h6>
+            <p>
+              Please fill out our request form,{' '}
+              <OutboundLink
+                analyticsEventLabel="Code School Add Request"
+                href="https://op.co.de/code-school-request"
+              >
+                here
+              </OutboundLink>
+              .
+            </p>
+          </aside>
+        </Section>
+        <Section theme="mist" title="Schools" hasHeadingLines={false}>
+          {state.schools.map(school => (
+            <div key={`${Math.random()}`}>{school.name}</div>
+          ))}
+        </Section>
+      </>
+    );
+  }
+}


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
- Simplify api utils and add API routes as constants
- Remove test coverage from code that doesn't have anything to be tested
- Add skeleton `/code_schools` page to showcase API consumption
- Add `React` as a global name-space to all JS files in `pages` folder.