### PR TITLE
Storybook Fonts set to PF Din Display and Noto Serif

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -5,9 +5,9 @@
         font-weight: normal;
 
         src:
-            url("static/fonts/PFDinDisplayPro-Reg.ttf") format("truetype"),
-            url("static/fonts/PFDinDisplayPro-Reg.woff2") format("woff2"),
-            url("static/fonts/PFDinDisplayPro-Reg.woff") format("woff)");
+            url("/fonts/PFDinDisplayPro-Reg.ttf") format("truetype"),
+            url("/fonts/PFDinDisplayPro-Reg.woff2") format("woff2"),
+            url("/fonts/PFDinDisplayPro-Reg.woff") format("woff)");
     }
 </style>
 <script>try { Typekit.load(); } catch (e) { }</script>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,14 @@
+<link href="https://fonts.googleapis.com/css?family=Noto+Serif" rel="stylesheet">
+<style>
+    @font-face {
+        font-family: "PF Din Display";
+        font-weight: normal;
+
+        /* prettier-ignore */
+        src:
+            url("/static/fonts/PFDinDisplayPro-Reg.ttf") format("truetype"),
+            url("/static/fonts/PFDinDisplayPro-Reg.woff2") format("woff2"),
+            url("/static/fonts/PFDinDisplayPro-Reg.woff") format("woff)");
+    }
+</style>
+<script>try{ Typekit.load(); } catch(e){ }</script>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,14 +1,13 @@
 <link href="https://fonts.googleapis.com/css?family=Noto+Serif" rel="stylesheet">
-<style>
+<style type="text/css">
     @font-face {
         font-family: "PF Din Display";
         font-weight: normal;
 
-        /* prettier-ignore */
         src:
             url("/static/fonts/PFDinDisplayPro-Reg.ttf") format("truetype"),
             url("/static/fonts/PFDinDisplayPro-Reg.woff2") format("woff2"),
             url("/static/fonts/PFDinDisplayPro-Reg.woff") format("woff)");
     }
 </style>
-<script>try{ Typekit.load(); } catch(e){ }</script>
+<script>try { Typekit.load(); } catch (e) { }</script>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -5,9 +5,9 @@
         font-weight: normal;
 
         src:
-            url("/static/fonts/PFDinDisplayPro-Reg.ttf") format("truetype"),
-            url("/static/fonts/PFDinDisplayPro-Reg.woff2") format("woff2"),
-            url("/static/fonts/PFDinDisplayPro-Reg.woff") format("woff)");
+            url("static/fonts/PFDinDisplayPro-Reg.ttf") format("truetype"),
+            url("static/fonts/PFDinDisplayPro-Reg.woff2") format("woff2"),
+            url("static/fonts/PFDinDisplayPro-Reg.woff") format("woff)");
     }
 </style>
 <script>try { Typekit.load(); } catch (e) { }</script>

--- a/components/FeaturedJobItem/__stories__/FeaturedJobItem.stories.js
+++ b/components/FeaturedJobItem/__stories__/FeaturedJobItem.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, text, boolean } from '@storybook/addon-knobs';
 
 import FeaturedJobItem from '../FeaturedJobItem';
 
-storiesOf('Common/FeaturedJobItem', module)
+storiesOf('FeaturedJobItem', module)
   .addDecorator(withKnobs)
   .add('default', () => (
     <FeaturedJobItem

--- a/components/FeaturedJobItem/__stories__/__snapshots__/FeaturedJobItem.stories.storyshot
+++ b/components/FeaturedJobItem/__stories__/__snapshots__/FeaturedJobItem.stories.storyshot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Common/FeaturedJobItem default 1`] = `
+exports[`Storyshots FeaturedJobItem default 1`] = `
 <article
   className="job"
 >


### PR DESCRIPTION
# Description of changes
Added preview-head.html to storybook config folder.
  - link tag for Noto Serif font.
  - style tag for @font-face for PF Din Display.


# Issue Resolved
Fixes #179 

## Screenshots/GIFs
**After:**
![AdBanner After](https://i.gyazo.com/10a2a5145777c4adb9c56dad977e2cbb.png)
![SchoolCard After](https://i.gyazo.com/b0ff8b4b7aafacd32c5d8ccb4bb3f524.png)

**Before:**
![AdBanner Before](https://i.gyazo.com/8856708e043bcc217394893ce879868f.png)
![SchoolCard Before](https://i.gyazo.com/4975d95b93c18d41b0063db971c87114.png)
