### PR TITLE
[Chore] - Lint, refactor, and make uniform all tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,7 +24,7 @@
     "jest/expect-expect": [
       "error",
       {
-        "assertFunctionNames": ["expect"]
+        "assertFunctionNames": ["expect", "createShallowSnapshotTest", "createSnapshotTest"]
       }
     ],
 

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,11 @@
 {
-  "extends": ["airbnb", "plugin:jsx-a11y/recommended", "prettier", "prettier/react"],
+  "extends": [
+    "airbnb",
+    "plugin:jsx-a11y/recommended",
+    "prettier",
+    "prettier/react",
+    "plugin:jest/recommended"
+  ],
   "env": {
     "browser": true,
     "commonjs": true,
@@ -8,11 +14,34 @@
     "node": true
   },
   "parser": "babel-eslint",
+  "plugins": ["jest"],
   "rules": {
     "comma-dangle": ["error", "only-multiline"],
     "import/no-unresolved": "off",
     "import/extensions": "off",
     "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
+    "jest/consistent-test-it": ["error", { "fn": "it", "withinDescribe": "it" }],
+    "jest/expect-expect": [
+      "error",
+      {
+        "assertFunctionNames": ["expect"]
+      }
+    ],
+
+    "jest/lowercase-name": [
+      "error",
+      {
+        "ignore": ["describe"]
+      }
+    ],
+    "jest/no-jasmine-globals": "error",
+    "jest/no-test-prefixes": "error",
+    "jest/no-test-return-statement": "error",
+    "jest/prefer-strict-equal": "error",
+    "jest/prefer-to-be-null": "error",
+    "jest/prefer-to-be-undefined": "error",
+    "jest/require-tothrow-message": "error",
+    "jest/valid-describe": "error",
     "jsx-a11y/anchor-is-valid": [
       "error",
       {
@@ -45,14 +74,14 @@
       }
     ],
     "react/forbid-prop-types": ["error", { "forbid": ["any"] }],
-    "react/jsx-filename-extension": ["error", { "extensions": [".js"] }],
     "react/jsx-curly-brace-presence": ["error", { "props": "never", "children": "never" }],
+    "react/jsx-filename-extension": ["error", { "extensions": [".js"] }],
     "react/jsx-max-props-per-line": ["error", { "maximum": 1, "when": "multiline" }],
     "react/jsx-one-expression-per-line": "off",
-    "react/prefer-stateless-function": ["off"],
     "react/no-did-mount-set-state": "off",
     "react/no-unused-prop-types": "off",
-    "react/no-unused-state": "error"
+    "react/no-unused-state": "error",
+    "react/prefer-stateless-function": ["off"]
   },
   "overrides": [
     {

--- a/common/styles/styleExports.js
+++ b/common/styles/styleExports.js
@@ -1,4 +1,4 @@
-import capitalizeFirstLetter from 'common/utils/string-utils';
+import { capitalizeFirstLetter } from 'common/utils/string-utils';
 import * as themeMap from './themeMap';
 
 const colorHexCodes = Object.entries(themeMap);

--- a/common/utils/__tests__/prop-utils.test.js
+++ b/common/utils/__tests__/prop-utils.test.js
@@ -1,52 +1,54 @@
 /* eslint-env jest */
 import { getPropsStartingWith, getDataAttributes, getAriaAttributes } from '../prop-utils';
 
-describe('getPropsStartingWith', () => {
-  test('should return the props that start with the given string', () => {
-    const props = {
-      'test-1': 'test',
-      'test-2': 'test 2',
-      'another-prop': 'test 3',
-    };
+describe('Prop Utilities', () => {
+  describe('getPropsStartingWith', () => {
+    it('should return the props that start with the given string', () => {
+      const props = {
+        'test-1': 'test',
+        'test-2': 'test 2',
+        'another-prop': 'test 3',
+      };
 
-    const result = getPropsStartingWith('test-', props);
-    expect(result).toEqual({
-      'test-1': 'test',
-      'test-2': 'test 2',
+      const result = getPropsStartingWith('test-', props);
+      expect(result).toStrictEqual({
+        'test-1': 'test',
+        'test-2': 'test 2',
+      });
     });
   });
-});
 
-describe('getDataAttributes', () => {
-  test('should return only the props that start with `data-`', () => {
-    const props = {
-      'data-ci': 'ci',
-      'data-gtm': 'gtm',
-      children: 'test children',
-    };
+  describe('getDataAttributes', () => {
+    it('should return only the props that start with `data-`', () => {
+      const props = {
+        'data-ci': 'ci',
+        'data-gtm': 'gtm',
+        children: 'test children',
+      };
 
-    const result = getDataAttributes(props);
+      const result = getDataAttributes(props);
 
-    expect(result).toEqual({
-      'data-ci': 'ci',
-      'data-gtm': 'gtm',
+      expect(result).toStrictEqual({
+        'data-ci': 'ci',
+        'data-gtm': 'gtm',
+      });
     });
   });
-});
 
-describe('getAriaAttributes', () => {
-  test('should return only the props that start with `aria-`', () => {
-    const props = {
-      'aria-label': 'a11y rocks!',
-      'aria-checked': 'true',
-      children: 'test children',
-    };
+  describe('getAriaAttributes', () => {
+    it('should return only the props that start with `aria-`', () => {
+      const props = {
+        'aria-label': 'a11y rocks!',
+        'aria-checked': 'true',
+        children: 'test children',
+      };
 
-    const result = getAriaAttributes(props);
+      const result = getAriaAttributes(props);
 
-    expect(result).toEqual({
-      'aria-label': 'a11y rocks!',
-      'aria-checked': 'true',
+      expect(result).toStrictEqual({
+        'aria-label': 'a11y rocks!',
+        'aria-checked': 'true',
+      });
     });
   });
 });

--- a/common/utils/__tests__/string-utils.test.js
+++ b/common/utils/__tests__/string-utils.test.js
@@ -1,26 +1,18 @@
 /* eslint-env jest */
-import capitalizeFirstLetter from '../string-utils';
+import { capitalizeFirstLetter } from '../string-utils';
 
-describe('capitalizeFirstLetter', () => {
-  it('should capitalize the first letter of a string with a lower-case first letter', () => {
-    expect(capitalizeFirstLetter('testString')).toEqual('TestString');
-  });
+describe('String Utilities', () => {
+  describe('capitalizeFirstLetter', () => {
+    it('should capitalize the first letter of a string with a lower-case first letter', () => {
+      expect(capitalizeFirstLetter('testString')).toStrictEqual('TestString');
+    });
 
-  it('should return the same string when passed a string with a capitalized first letter', () => {
-    const testString = 'TestString';
+    it('should return the same string when passed a string with a capitalized first letter', () => {
+      expect(capitalizeFirstLetter('TestString')).toStrictEqual('TestString');
+    });
 
-    expect(capitalizeFirstLetter(testString)).toEqual(testString);
-  });
-
-  it('should throw an error when passed undefined', () => {
-    expect(() => capitalizeFirstLetter()).toThrow();
-  });
-
-  it('should throw an error when passed an object', () => {
-    expect(() => capitalizeFirstLetter({ key: 'value' })).toThrow();
-  });
-
-  it('should throw an error when passed an array', () => {
-    expect(() => capitalizeFirstLetter(['item1', 'item2'])).toThrow();
+    it('should return an empty string when passed undefined', () => {
+      expect(capitalizeFirstLetter()).toStrictEqual('');
+    });
   });
 });

--- a/common/utils/__tests__/validator-utils.test.js
+++ b/common/utils/__tests__/validator-utils.test.js
@@ -1,30 +1,18 @@
 /* eslint-env jest */
-import { zipCodeValidator } from '../validator-utils';
+import { zipCodeStringValidator } from '../validator-utils';
 
-describe('capitalizeFirstLetter', () => {
-  it('should return true for any string', () => {
-    // this may seem counter-intuitive, but it's difficult to get a zipcode regex correctly.
-    // see https://stackoverflow.com/questions/578406/what-is-the-ultimate-postal-code-and-zip-regex for more info
-    expect(zipCodeValidator('testString')).toEqual(true);
-  });
+describe('Validator Utilities', () => {
+  describe('zipCodeStringValidator', () => {
+    it('should return true for any string', () => {
+      expect(zipCodeStringValidator('testString')).toStrictEqual(true);
+    });
 
-  it('should return false when passed an empty string', () => {
-    expect(zipCodeValidator('')).toEqual(false);
-  });
+    it('should return false when passed an empty string', () => {
+      expect(zipCodeStringValidator('')).toStrictEqual(false);
+    });
 
-  it('should throw an error when passed any amount of number characters', () => {
-    expect(() => zipCodeValidator(12)).toThrow();
-  });
-
-  it('should throw an error when passed undefined', () => {
-    expect(() => zipCodeValidator()).toThrow();
-  });
-
-  it('should throw an error when passed an object', () => {
-    expect(() => zipCodeValidator({ key: 'value' })).toThrow();
-  });
-
-  it('should throw an error when passed an array', () => {
-    expect(() => zipCodeValidator(['item1', 'item2'])).toThrow();
+    it('should return false when passed undefined', () => {
+      expect(zipCodeStringValidator()).toStrictEqual(false);
+    });
   });
 });

--- a/common/utils/string-utils.js
+++ b/common/utils/string-utils.js
@@ -1,3 +1,6 @@
+// Remove lint error below when a second validator is added.
+/* eslint-disable import/prefer-default-export */
+
 /**
  * Capitalize the first letter in a string
  *
@@ -5,7 +8,7 @@
  * @param {string} someString
  * @returns {string} Returns string with the first character capitalized
  */
-export default function capitalizeFirstLetter(someString) {
+export function capitalizeFirstLetter(someString = '') {
   const stringCopy = someString.slice(0);
 
   return stringCopy.charAt(0).toUpperCase() + stringCopy.slice(1);

--- a/common/utils/validator-utils.js
+++ b/common/utils/validator-utils.js
@@ -1,5 +1,6 @@
 // Remove lint error below when a second validator is added.
 /* eslint-disable import/prefer-default-export */
+
 /**
  * Take a string and determine if it has non-whitespace characters in it
  *
@@ -10,4 +11,6 @@
  * @param {string} input
  * @returns {boolean}
  */
-export const zipCodeValidator = input => input.length !== 0 && input.trim().length !== 0;
+export function zipCodeStringValidator(input = '') {
+  return input.length !== 0 && input.trim().length !== 0;
+}

--- a/components/AdBanner/__tests__/AdBanner.test.js
+++ b/components/AdBanner/__tests__/AdBanner.test.js
@@ -4,7 +4,7 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import AdBanner from '../AdBanner';
 
 describe('AdBanner', () => {
-  test('it should render properly with required props', () => {
+  it('it should render properly with required props', () => {
     createShallowSnapshotTest(
       <AdBanner altText="Some text" href="www.test.com" imageSource="www.imagetest.com">
         Test
@@ -12,7 +12,7 @@ describe('AdBanner', () => {
     );
   });
 
-  test('should render properly with some props assigned', () => {
+  it('should render properly with some props assigned', () => {
     createShallowSnapshotTest(
       <AdBanner
         altText="Alt text test"

--- a/components/AdBanner/__tests__/AdBanner.test.js
+++ b/components/AdBanner/__tests__/AdBanner.test.js
@@ -4,7 +4,7 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import AdBanner from '../AdBanner';
 
 describe('AdBanner', () => {
-  it('it should render properly with required props', () => {
+  it('should render with required props', () => {
     createShallowSnapshotTest(
       <AdBanner altText="Some text" href="www.test.com" imageSource="www.imagetest.com">
         Test
@@ -12,7 +12,7 @@ describe('AdBanner', () => {
     );
   });
 
-  it('should render properly with some props assigned', () => {
+  it('should render with all props assigned', () => {
     createShallowSnapshotTest(
       <AdBanner
         altText="Alt text test"

--- a/components/AdBanner/__tests__/__snapshots__/AdBanner.test.js.snap
+++ b/components/AdBanner/__tests__/__snapshots__/AdBanner.test.js.snap
@@ -1,34 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AdBanner it should render properly with required props 1`] = `
-<OutboundLink
-  analyticsEventLabel="[AdBanner Hit]"
-  className="adBannerLink"
-  hasIcon={false}
-  href="www.test.com"
->
-  <div
-    className="adBanner"
-  >
-    <div
-      className="adBannerImageContainer"
-    >
-      <img
-        alt="Some text"
-        className="adBannerImage"
-        src="www.imagetest.com"
-      />
-    </div>
-    <h4
-      className="adBannerText"
-    >
-      Test
-    </h4>
-  </div>
-</OutboundLink>
-`;
-
-exports[`AdBanner should render properly with some props assigned 1`] = `
+exports[`AdBanner should render with all props assigned 1`] = `
 <OutboundLink
   analyticsEventLabel="[AdBanner Hit]"
   className="AdBanner-class adBannerLink"
@@ -45,6 +17,34 @@ exports[`AdBanner should render properly with some props assigned 1`] = `
         alt="Alt text test"
         className="adBannerImage"
         src="test-image.jpg"
+      />
+    </div>
+    <h4
+      className="adBannerText"
+    >
+      Test
+    </h4>
+  </div>
+</OutboundLink>
+`;
+
+exports[`AdBanner should render with required props 1`] = `
+<OutboundLink
+  analyticsEventLabel="[AdBanner Hit]"
+  className="adBannerLink"
+  hasIcon={false}
+  href="www.test.com"
+>
+  <div
+    className="adBanner"
+  >
+    <div
+      className="adBannerImageContainer"
+    >
+      <img
+        alt="Some text"
+        className="adBannerImage"
+        src="www.imagetest.com"
       />
     </div>
     <h4

--- a/components/Cards/ImageCard/__tests__/ImageCard.test.js
+++ b/components/Cards/ImageCard/__tests__/ImageCard.test.js
@@ -5,7 +5,7 @@ import Button from 'components/_common_/Button/Button';
 import ImageCard from '../ImageCard';
 
 describe('ImageCard', () => {
-  test('it should render properly with required props', () => {
+  it('it should render properly with required props', () => {
     createShallowSnapshotTest(
       <ImageCard alt="Test title" imageSource="/static/images/Family1.jpg">
         <p>Testing!</p>
@@ -13,7 +13,7 @@ describe('ImageCard', () => {
     );
   });
 
-  test('should render properly with some props assigned', () => {
+  it('should render properly with some props assigned', () => {
     createShallowSnapshotTest(
       <ImageCard alt="Title Tester" imageSource="/static/images/TankFlip.gif">
         <p>

--- a/components/Cards/ImageCard/__tests__/ImageCard.test.js
+++ b/components/Cards/ImageCard/__tests__/ImageCard.test.js
@@ -1,24 +1,13 @@
 import React from 'react';
 import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 
-import Button from 'components/_common_/Button/Button';
 import ImageCard from '../ImageCard';
 
 describe('ImageCard', () => {
-  it('it should render properly with required props', () => {
+  it('should render with required props', () => {
     createShallowSnapshotTest(
       <ImageCard alt="Test title" imageSource="/static/images/Family1.jpg">
         <p>Testing!</p>
-      </ImageCard>,
-    );
-  });
-
-  it('should render properly with some props assigned', () => {
-    createShallowSnapshotTest(
-      <ImageCard alt="Title Tester" imageSource="/static/images/TankFlip.gif">
-        <p>
-          Testing with a button: <Button href="https://www.testlink.com">Test me!</Button>
-        </p>
       </ImageCard>,
     );
   });

--- a/components/Cards/ImageCard/__tests__/__snapshots__/ImageCard.test.js.snap
+++ b/components/Cards/ImageCard/__tests__/__snapshots__/ImageCard.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ImageCard it should render properly with required props 1`] = `
+exports[`ImageCard should render with required props 1`] = `
 <Card
   className="ImageCard"
   hasAnimationOnHover={false}
@@ -15,45 +15,6 @@ exports[`ImageCard it should render properly with required props 1`] = `
   >
     <p>
       Testing!
-    </p>
-  </div>
-</Card>
-`;
-
-exports[`ImageCard should render properly with some props assigned 1`] = `
-<Card
-  className="ImageCard"
-  hasAnimationOnHover={false}
->
-  <img
-    alt="Title Tester"
-    className="image"
-    src="/static/images/TankFlip.gif"
-  />
-  <div
-    className="content"
-  >
-    <p>
-      Testing with a button: 
-      <Button
-        analyticsObject={
-          Object {
-            "action": "Button Selected",
-            "category": "Interactions",
-          }
-        }
-        className=""
-        datum=""
-        disabled={false}
-        fullWidth={false}
-        href="https://www.testlink.com"
-        onClick={[Function]}
-        tabIndex={0}
-        theme="primary"
-        type="button"
-      >
-        Test me!
-      </Button>
     </p>
   </div>
 </Card>

--- a/components/Cards/SchoolCard/__tests__/SchoolCard.test.js
+++ b/components/Cards/SchoolCard/__tests__/SchoolCard.test.js
@@ -6,7 +6,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import SchoolCard from '../SchoolCard';
 
 describe('SchoolCard', () => {
-  it('should render properly with all props assigned', () => {
+  it('should render with all props assigned', () => {
     createSnapshotTest(
       <SchoolCard
         schoolWebsite="https://www.codeplatoon.org"
@@ -22,7 +22,7 @@ describe('SchoolCard', () => {
     );
   });
 
-  it('should render properly with all required assigned', () => {
+  it('should render with required props', () => {
     createSnapshotTest(
       <SchoolCard
         schoolWebsite="https://www.codeplatoon.org/not-real"

--- a/components/Cards/SchoolCard/__tests__/SchoolCard.test.js
+++ b/components/Cards/SchoolCard/__tests__/SchoolCard.test.js
@@ -6,7 +6,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import SchoolCard from '../SchoolCard';
 
 describe('SchoolCard', () => {
-  test('should render properly with all props assigned', () => {
+  it('should render properly with all props assigned', () => {
     createSnapshotTest(
       <SchoolCard
         schoolWebsite="https://www.codeplatoon.org"
@@ -22,7 +22,7 @@ describe('SchoolCard', () => {
     );
   });
 
-  test('should render properly with all required assigned', () => {
+  it('should render properly with all required assigned', () => {
     createSnapshotTest(
       <SchoolCard
         schoolWebsite="https://www.codeplatoon.org/not-real"

--- a/components/Cards/SchoolCard/__tests__/__snapshots__/SchoolCard.test.js.snap
+++ b/components/Cards/SchoolCard/__tests__/__snapshots__/SchoolCard.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SchoolCard should render properly with all props assigned 1`] = `
+exports[`SchoolCard should render with all props assigned 1`] = `
 <a
   className="cardLinkOverrides"
   href="https://www.codeplatoon.org"
@@ -65,7 +65,7 @@ exports[`SchoolCard should render properly with all props assigned 1`] = `
 </a>
 `;
 
-exports[`SchoolCard should render properly with all required assigned 1`] = `
+exports[`SchoolCard should render with required props 1`] = `
 <a
   className="cardLinkOverrides"
   href="https://www.codeplatoon.org/not-real"

--- a/components/Cards/TeamMemberCard/__tests__/TeamMemberCard.test.js
+++ b/components/Cards/TeamMemberCard/__tests__/TeamMemberCard.test.js
@@ -5,7 +5,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import TeamMemberCard from '../TeamMemberCard';
 
 describe('TeamMemberCard', () => {
-  test('should render properly with all required props assigned', () => {
+  it('should render properly with all required props assigned', () => {
     createSnapshotTest(
       <TeamMemberCard
         imageAlternateText="Kyle's beautiful face"
@@ -16,7 +16,7 @@ describe('TeamMemberCard', () => {
     );
   });
 
-  test('should render properly with all props assigned', () => {
+  it('should render properly with all props assigned', () => {
     createSnapshotTest(
       <TeamMemberCard
         email="inbox@kylemh.com"

--- a/components/Cards/TeamMemberCard/__tests__/TeamMemberCard.test.js
+++ b/components/Cards/TeamMemberCard/__tests__/TeamMemberCard.test.js
@@ -5,7 +5,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import TeamMemberCard from '../TeamMemberCard';
 
 describe('TeamMemberCard', () => {
-  it('should render properly with all required props assigned', () => {
+  it('should render with required props', () => {
     createSnapshotTest(
       <TeamMemberCard
         imageAlternateText="Kyle's beautiful face"
@@ -16,7 +16,7 @@ describe('TeamMemberCard', () => {
     );
   });
 
-  it('should render properly with all props assigned', () => {
+  it('should render with all props assigned', () => {
     createSnapshotTest(
       <TeamMemberCard
         email="inbox@kylemh.com"

--- a/components/Cards/TeamMemberCard/__tests__/__snapshots__/TeamMemberCard.test.js.snap
+++ b/components/Cards/TeamMemberCard/__tests__/__snapshots__/TeamMemberCard.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TeamMemberCard should render properly with all props assigned 1`] = `
+exports[`TeamMemberCard should render with all props assigned 1`] = `
 <article
   className="Card TeamMemberCard animatedCard"
 >
@@ -69,7 +69,7 @@ exports[`TeamMemberCard should render properly with all props assigned 1`] = `
 </article>
 `;
 
-exports[`TeamMemberCard should render properly with all required props assigned 1`] = `
+exports[`TeamMemberCard should render with required props 1`] = `
 <article
   className="Card TeamMemberCard animatedCard"
 >

--- a/components/Cards/ValueCard/__tests__/ValueCard.test.js
+++ b/components/Cards/ValueCard/__tests__/ValueCard.test.js
@@ -5,7 +5,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import ValueCard from '../ValueCard';
 
 describe('ValueCard', () => {
-  test('should render properly with all required props assigned', () => {
+  it('should render properly with all required props assigned', () => {
     createSnapshotTest(
       <ValueCard
         name="Testing"

--- a/components/Cards/ValueCard/__tests__/ValueCard.test.js
+++ b/components/Cards/ValueCard/__tests__/ValueCard.test.js
@@ -5,7 +5,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import ValueCard from '../ValueCard';
 
 describe('ValueCard', () => {
-  it('should render properly with all required props assigned', () => {
+  it('should render with required props', () => {
     createSnapshotTest(
       <ValueCard
         name="Testing"

--- a/components/Cards/ValueCard/__tests__/__snapshots__/ValueCard.test.js.snap
+++ b/components/Cards/ValueCard/__tests__/__snapshots__/ValueCard.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ValueCard should render properly with all required props assigned 1`] = `
+exports[`ValueCard should render with required props 1`] = `
 <article
   className="Card ValueCard"
 >

--- a/components/ClipPathImage/__tests__/ClipPathImage.test.js
+++ b/components/ClipPathImage/__tests__/ClipPathImage.test.js
@@ -4,7 +4,7 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import ClipPathImage from '../ClipPathImage';
 
 describe('ClipPathImage', () => {
-  test('it should render properly with required props', () => {
+  it('it should render properly with required props', () => {
     createShallowSnapshotTest(
       <ClipPathImage imageSource="image.png" title="Test title">
         Test
@@ -12,7 +12,7 @@ describe('ClipPathImage', () => {
     );
   });
 
-  test('it should render properly with some props assigned', () => {
+  it('it should render properly with some props assigned', () => {
     createShallowSnapshotTest(
       <ClipPathImage
         altText="Test picture"

--- a/components/ClipPathImage/__tests__/ClipPathImage.test.js
+++ b/components/ClipPathImage/__tests__/ClipPathImage.test.js
@@ -4,26 +4,18 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import ClipPathImage from '../ClipPathImage';
 
 describe('ClipPathImage', () => {
-  it('it should render properly with required props', () => {
-    createShallowSnapshotTest(
-      <ClipPathImage imageSource="image.png" title="Test title">
-        Test
-      </ClipPathImage>,
-    );
+  it('should render with required props', () => {
+    createShallowSnapshotTest(<ClipPathImage imageSource="image.png" title="Test title" />);
   });
 
-  it('it should render properly with some props assigned', () => {
+  it('should render with all props assigned', () => {
     createShallowSnapshotTest(
       <ClipPathImage
         altText="Test picture"
-        className="clipPathImage"
         imageSource="test.png"
-        href="www.test.com"
-        theme="primary"
+        theme="secondary"
         title="Test title"
-      >
-        Test
-      </ClipPathImage>,
+      />,
     );
   });
 });

--- a/components/ClipPathImage/__tests__/__snapshots__/ClipPathImage.test.js.snap
+++ b/components/ClipPathImage/__tests__/__snapshots__/ClipPathImage.test.js.snap
@@ -1,6 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ClipPathImage it should render properly with required props 1`] = `
+exports[`ClipPathImage should render with all props assigned 1`] = `
+<Card
+  className="ClipPathImage"
+  hasAnimationOnHover={false}
+>
+  <div
+    className="secondary content"
+  >
+    <img
+      alt="Test picture"
+      className="image"
+      src="test.png"
+    />
+    <h6
+      className="title"
+    >
+      Test title
+    </h6>
+  </div>
+</Card>
+`;
+
+exports[`ClipPathImage should render with required props 1`] = `
 <Card
   className="ClipPathImage"
   hasAnimationOnHover={false}
@@ -12,28 +34,6 @@ exports[`ClipPathImage it should render properly with required props 1`] = `
       alt=""
       className="image"
       src="image.png"
-    />
-    <h6
-      className="title"
-    >
-      Test title
-    </h6>
-  </div>
-</Card>
-`;
-
-exports[`ClipPathImage it should render properly with some props assigned 1`] = `
-<Card
-  className="ClipPathImage"
-  hasAnimationOnHover={false}
->
-  <div
-    className="primary content"
-  >
-    <img
-      alt="Test picture"
-      className="image"
-      src="test.png"
     />
     <h6
       className="title"

--- a/components/ErrorDisplay/__tests__/ErrorDisplay.test.js
+++ b/components/ErrorDisplay/__tests__/ErrorDisplay.test.js
@@ -5,7 +5,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import ErrorDisplay from '../ErrorDisplay';
 
 describe('ErrorDisplay', () => {
-  test('should render with just required props', () => {
+  it('should render with just required props', () => {
     createSnapshotTest(<ErrorDisplay statusCode={404}>Err!</ErrorDisplay>);
   });
 });

--- a/components/FAQ/__tests__/FAQItem.test.js
+++ b/components/FAQ/__tests__/FAQItem.test.js
@@ -4,7 +4,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import FAQItem from '../FAQItem/FAQItem';
 
 describe('FAQItem', () => {
-  it('should render properly with required props', () => {
+  it('should render with required props', () => {
     createSnapshotTest(<FAQItem question="How do I test things?" answer={<>Like so!</>} />);
   });
 });

--- a/components/FAQ/__tests__/FAQItem.test.js
+++ b/components/FAQ/__tests__/FAQItem.test.js
@@ -4,7 +4,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import FAQItem from '../FAQItem/FAQItem';
 
 describe('FAQItem', () => {
-  test('should render properly with required props', () => {
+  it('should render properly with required props', () => {
     createSnapshotTest(<FAQItem question="How do I test things?" answer={<>Like so!</>} />);
   });
 });

--- a/components/FAQ/__tests__/__snapshots__/FAQItem.test.js.snap
+++ b/components/FAQ/__tests__/__snapshots__/FAQItem.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FAQItem should render properly with required props 1`] = `
+exports[`FAQItem should render with required props 1`] = `
 <div
   className="accordionSingle"
 >

--- a/components/FeaturedJobItem/__tests__/FeaturedJobItem.test.js
+++ b/components/FeaturedJobItem/__tests__/FeaturedJobItem.test.js
@@ -4,7 +4,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import FeaturedJobItem from '../FeaturedJobItem';
 
 describe('FeaturedJobItem', () => {
-  it('should render with just required props passed', () => {
+  it('should render with required props', () => {
     createSnapshotTest(
       <FeaturedJobItem
         title="DevOps Engineer"
@@ -15,7 +15,7 @@ describe('FeaturedJobItem', () => {
     );
   });
 
-  it('should render properly with all props assigned', () => {
+  it('should render with all props assigned', () => {
     createSnapshotTest(
       <FeaturedJobItem
         title="Experienced React Engineer"

--- a/components/FeaturedJobItem/__tests__/__snapshots__/FeaturedJobItem.test.js.snap
+++ b/components/FeaturedJobItem/__tests__/__snapshots__/FeaturedJobItem.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FeaturedJobItem should render properly with all props assigned 1`] = `
+exports[`FeaturedJobItem should render with all props assigned 1`] = `
 <article
   className="job"
 >
@@ -83,7 +83,7 @@ exports[`FeaturedJobItem should render properly with all props assigned 1`] = `
 </article>
 `;
 
-exports[`FeaturedJobItem should render with just required props passed 1`] = `
+exports[`FeaturedJobItem should render with required props 1`] = `
 <article
   className="job"
 >

--- a/components/Footer/__tests__/Footer.test.js
+++ b/components/Footer/__tests__/Footer.test.js
@@ -4,5 +4,5 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import Footer from '../Footer';
 
 describe('Footer', () => {
-  it('it should render properly no props', () => createShallowSnapshotTest(<Footer />));
+  it('should render with no props passed', () => createShallowSnapshotTest(<Footer />));
 });

--- a/components/Footer/__tests__/Footer.test.js
+++ b/components/Footer/__tests__/Footer.test.js
@@ -4,5 +4,5 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import Footer from '../Footer';
 
 describe('Footer', () => {
-  test('it should render properly no props', () => createShallowSnapshotTest(<Footer />));
+  it('it should render properly no props', () => createShallowSnapshotTest(<Footer />));
 });

--- a/components/Footer/__tests__/__snapshots__/Footer.test.js.snap
+++ b/components/Footer/__tests__/__snapshots__/Footer.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Footer it should render properly no props 1`] = `
+exports[`Footer should render with no props passed 1`] = `
 <footer
   className="Footer"
 >

--- a/components/Press/CivicXBadge/__tests__/CivicXBadge.test.js
+++ b/components/Press/CivicXBadge/__tests__/CivicXBadge.test.js
@@ -4,5 +4,5 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import CivicXBadge from '../CivicXBadge';
 
 describe('CivicXBadge', () => {
-  it('it should render properly no props', () => createShallowSnapshotTest(<CivicXBadge />));
+  it('should render with no props passed', () => createShallowSnapshotTest(<CivicXBadge />));
 });

--- a/components/Press/CivicXBadge/__tests__/CivicXBadge.test.js
+++ b/components/Press/CivicXBadge/__tests__/CivicXBadge.test.js
@@ -4,5 +4,5 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import CivicXBadge from '../CivicXBadge';
 
 describe('CivicXBadge', () => {
-  test('it should render properly no props', () => createShallowSnapshotTest(<CivicXBadge />));
+  it('it should render properly no props', () => createShallowSnapshotTest(<CivicXBadge />));
 });

--- a/components/Press/CivicXBadge/__tests__/__snapshots__/CivicXBadge.test.js.snap
+++ b/components/Press/CivicXBadge/__tests__/__snapshots__/CivicXBadge.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CivicXBadge it should render properly no props 1`] = `
+exports[`CivicXBadge should render with no props passed 1`] = `
 <div>
   <OutboundLink
     analyticsEventLabel="[CivicX Accelerator Badge] http://cvcx.org/veterans-solutions-lab/"

--- a/components/Press/PressLinks/ArticleGroup/ArticleGroup.js
+++ b/components/Press/PressLinks/ArticleGroup/ArticleGroup.js
@@ -33,13 +33,10 @@ class ArticleGroup extends Component {
         <ul>
           {articles.map((link, index) => {
             const isArticleVisible = areAllLinksVisible || index < numberOfInitiallyVisibleLinks;
-      
+
             return isArticleVisible ? (
               <li key={`GroupLink_${link.url}`}>
-                <OutboundLink
-                  href={link.url}
-                  analyticsEventLabel="Press Article"
-                >
+                <OutboundLink href={link.url} analyticsEventLabel="Press Article">
                   {link.title}
                 </OutboundLink>
               </li>

--- a/components/Press/PressLinks/ArticleGroup/__tests__/ArticleGroup.test.js
+++ b/components/Press/PressLinks/ArticleGroup/__tests__/ArticleGroup.test.js
@@ -5,7 +5,7 @@ import { mount, shallow } from 'enzyme';
 import ArticleGroup from '../ArticleGroup';
 
 describe('ArticleGroup', () => {
-  test('should render properly with required props', () =>
+  it('should render properly with required props', () =>
     createShallowSnapshotTest(
       <ArticleGroup
         region="test"
@@ -14,7 +14,7 @@ describe('ArticleGroup', () => {
       />,
     ));
 
-  test('should render properly with required props and 3 links and a button', () =>
+  it('should render properly with required props and 3 links and a button', () =>
     createShallowSnapshotTest(
       <ArticleGroup
         region="test"
@@ -27,7 +27,7 @@ describe('ArticleGroup', () => {
       />,
     ));
 
-  test('should setState when clicking Show All button', () => {
+  it('should setState when clicking Show All button', () => {
     const ArticleGroupShallowInstance = shallow(
       <ArticleGroup
         region="test"
@@ -42,10 +42,10 @@ describe('ArticleGroup', () => {
 
     ArticleGroupShallowInstance.instance().clickHandler();
 
-    expect(ArticleGroupShallowInstance.state().areAllLinksVisible).toEqual(true);
+    expect(ArticleGroupShallowInstance.state().areAllLinksVisible).toStrictEqual(true);
   });
 
-  test('should not create a button if not enough links', () => {
+  it('should not create a button if not enough links', () => {
     const wrap = mount(
       <ArticleGroup
         region="test"
@@ -54,10 +54,10 @@ describe('ArticleGroup', () => {
       />,
     );
 
-    expect(wrap.find('button').exists()).toEqual(false);
+    expect(wrap.find('button').exists()).toStrictEqual(false);
   });
 
-  test('should create a button if enough links are available', () => {
+  it('should create a button if enough links are available', () => {
     const wrap = mount(
       <ArticleGroup
         region="test"
@@ -70,6 +70,6 @@ describe('ArticleGroup', () => {
       />,
     );
 
-    expect(wrap.find('button').exists()).toEqual(true);
+    expect(wrap.find('button').exists()).toStrictEqual(true);
   });
 });

--- a/components/Press/PressLinks/ArticleGroup/__tests__/ArticleGroup.test.js
+++ b/components/Press/PressLinks/ArticleGroup/__tests__/ArticleGroup.test.js
@@ -5,7 +5,7 @@ import { mount, shallow } from 'enzyme';
 import ArticleGroup from '../ArticleGroup';
 
 describe('ArticleGroup', () => {
-  it('should render properly with required props', () =>
+  it('should render with required props', () =>
     createShallowSnapshotTest(
       <ArticleGroup
         region="test"
@@ -14,7 +14,7 @@ describe('ArticleGroup', () => {
       />,
     ));
 
-  it('should render properly with required props and 3 links and a button', () =>
+  it('should render with required props and 3 links and a button', () =>
     createShallowSnapshotTest(
       <ArticleGroup
         region="test"

--- a/components/Press/PressLinks/ArticleGroup/__tests__/__snapshots__/ArticleGroup.test.js.snap
+++ b/components/Press/PressLinks/ArticleGroup/__tests__/__snapshots__/ArticleGroup.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ArticleGroup should render properly with required props 1`] = `
+exports[`ArticleGroup should render with required props 1`] = `
 <div
   className="articlesGroup"
 >
@@ -22,7 +22,7 @@ exports[`ArticleGroup should render properly with required props 1`] = `
 </div>
 `;
 
-exports[`ArticleGroup should render properly with required props and 3 links and a button 1`] = `
+exports[`ArticleGroup should render with required props and 3 links and a button 1`] = `
 <div
   className="articlesGroup"
 >

--- a/components/Press/PressLinks/__tests__/PressLinks.test.js
+++ b/components/Press/PressLinks/__tests__/PressLinks.test.js
@@ -4,5 +4,5 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import PressLinks from '../PressLinks';
 
 describe('PressLinks', () => {
-  test('it should render properly no props', () => createShallowSnapshotTest(<PressLinks />));
+  it('it should render properly no props', () => createShallowSnapshotTest(<PressLinks />));
 });

--- a/components/Press/PressLinks/__tests__/PressLinks.test.js
+++ b/components/Press/PressLinks/__tests__/PressLinks.test.js
@@ -4,5 +4,5 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import PressLinks from '../PressLinks';
 
 describe('PressLinks', () => {
-  it('it should render properly no props', () => createShallowSnapshotTest(<PressLinks />));
+  it('should render with no props passed', () => createShallowSnapshotTest(<PressLinks />));
 });

--- a/components/Press/PressLinks/__tests__/__snapshots__/PressLinks.test.js.snap
+++ b/components/Press/PressLinks/__tests__/__snapshots__/PressLinks.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PressLinks it should render properly no props 1`] = `
+exports[`PressLinks should render with no props passed 1`] = `
 <div
   className="logos"
 >

--- a/components/Press/PressPhotos/__tests__/PressPhotos.test.js
+++ b/components/Press/PressPhotos/__tests__/PressPhotos.test.js
@@ -4,5 +4,5 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import PressPhotos from '../PressPhotos';
 
 describe('PressPhotos', () => {
-  it('it should render properly no props', () => createShallowSnapshotTest(<PressPhotos />));
+  it('should render with no props passed', () => createShallowSnapshotTest(<PressPhotos />));
 });

--- a/components/Press/PressPhotos/__tests__/PressPhotos.test.js
+++ b/components/Press/PressPhotos/__tests__/PressPhotos.test.js
@@ -4,5 +4,5 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import PressPhotos from '../PressPhotos';
 
 describe('PressPhotos', () => {
-  test('it should render properly no props', () => createShallowSnapshotTest(<PressPhotos />));
+  it('it should render properly no props', () => createShallowSnapshotTest(<PressPhotos />));
 });

--- a/components/Press/PressPhotos/__tests__/__snapshots__/PressPhotos.test.js.snap
+++ b/components/Press/PressPhotos/__tests__/__snapshots__/PressPhotos.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PressPhotos it should render properly no props 1`] = `
+exports[`PressPhotos should render with no props passed 1`] = `
 <div
   className="photos"
 >

--- a/components/Press/PressVideos/__tests__/PressVideos.test.js
+++ b/components/Press/PressVideos/__tests__/PressVideos.test.js
@@ -4,5 +4,5 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import PressVideos from '../PressVideos';
 
 describe('PressVideos', () => {
-  it('it should render properly no props', () => createShallowSnapshotTest(<PressVideos />));
+  it('should render with no props passed', () => createShallowSnapshotTest(<PressVideos />));
 });

--- a/components/Press/PressVideos/__tests__/PressVideos.test.js
+++ b/components/Press/PressVideos/__tests__/PressVideos.test.js
@@ -4,5 +4,5 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import PressVideos from '../PressVideos';
 
 describe('PressVideos', () => {
-  test('it should render properly no props', () => createShallowSnapshotTest(<PressVideos />));
+  it('it should render properly no props', () => createShallowSnapshotTest(<PressVideos />));
 });

--- a/components/Press/PressVideos/__tests__/__snapshots__/PressVideos.test.js.snap
+++ b/components/Press/PressVideos/__tests__/__snapshots__/PressVideos.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PressVideos it should render properly no props 1`] = `
+exports[`PressVideos should render with no props passed 1`] = `
 <div
   className="pressVideos"
 >

--- a/components/ReusableSections/DonateSection/__tests__/DonateSection.test.js
+++ b/components/ReusableSections/DonateSection/__tests__/DonateSection.test.js
@@ -3,5 +3,6 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import DonateSection from '../DonateSection';
 
 describe('DonateSection', () => {
-  it('should render properly with no props', () => createShallowSnapshotTest(<DonateSection />));
+  it('should render with no props passed passed', () =>
+    createShallowSnapshotTest(<DonateSection />));
 });

--- a/components/ReusableSections/DonateSection/__tests__/DonateSection.test.js
+++ b/components/ReusableSections/DonateSection/__tests__/DonateSection.test.js
@@ -3,5 +3,5 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import DonateSection from '../DonateSection';
 
 describe('DonateSection', () => {
-  test('should render properly with no props', () => createShallowSnapshotTest(<DonateSection />));
+  it('should render properly with no props', () => createShallowSnapshotTest(<DonateSection />));
 });

--- a/components/ReusableSections/DonateSection/__tests__/__snapshots__/DonateSection.test.js.snap
+++ b/components/ReusableSections/DonateSection/__tests__/__snapshots__/DonateSection.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DonateSection should render properly with no props 1`] = `
+exports[`DonateSection should render with no props passed passed 1`] = `
 <Section
   className="DonateSection"
   contentClassName=""

--- a/components/ReusableSections/JoinSection/__tests__/JoinSection.test.js
+++ b/components/ReusableSections/JoinSection/__tests__/JoinSection.test.js
@@ -3,5 +3,5 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import JoinSection from '../JoinSection';
 
 describe('JoinSection', () => {
-  it('it should render properly with no props', () => createShallowSnapshotTest(<JoinSection />));
+  it('should render with no props passed passed', () => createShallowSnapshotTest(<JoinSection />));
 });

--- a/components/ReusableSections/JoinSection/__tests__/JoinSection.test.js
+++ b/components/ReusableSections/JoinSection/__tests__/JoinSection.test.js
@@ -3,5 +3,5 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import JoinSection from '../JoinSection';
 
 describe('JoinSection', () => {
-  test('it should render properly with no props', () => createShallowSnapshotTest(<JoinSection />));
+  it('it should render properly with no props', () => createShallowSnapshotTest(<JoinSection />));
 });

--- a/components/ReusableSections/JoinSection/__tests__/__snapshots__/JoinSection.test.js.snap
+++ b/components/ReusableSections/JoinSection/__tests__/__snapshots__/JoinSection.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`JoinSection it should render properly with no props 1`] = `
+exports[`JoinSection should render with no props passed passed 1`] = `
 <Section
   className="JoinSection"
   contentClassName=""

--- a/components/ReusableSections/SignUpSection/__tests__/SignUpSection.test.js
+++ b/components/ReusableSections/SignUpSection/__tests__/SignUpSection.test.js
@@ -4,7 +4,7 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import SignUpSection from '../SignUpSection';
 
 describe('SignUpSection', () => {
-  it('it should render properly with no props', () => {
+  it('should render with no props passed passed', () => {
     createShallowSnapshotTest(<SignUpSection />);
   });
 });

--- a/components/ReusableSections/SignUpSection/__tests__/SignUpSection.test.js
+++ b/components/ReusableSections/SignUpSection/__tests__/SignUpSection.test.js
@@ -4,7 +4,7 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import SignUpSection from '../SignUpSection';
 
 describe('SignUpSection', () => {
-  test('it should render properly with no props', () => {
+  it('it should render properly with no props', () => {
     createShallowSnapshotTest(<SignUpSection />);
   });
 });

--- a/components/ReusableSections/SignUpSection/__tests__/__snapshots__/SignUpSection.test.js.snap
+++ b/components/ReusableSections/SignUpSection/__tests__/__snapshots__/SignUpSection.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SignUpSection it should render properly with no props 1`] = `
+exports[`SignUpSection should render with no props passed passed 1`] = `
 <Section
   className=""
   contentClassName=""

--- a/components/SocialMedia/SocialMediaContainer/__tests__/SocialMediaContainer.test.js
+++ b/components/SocialMedia/SocialMediaContainer/__tests__/SocialMediaContainer.test.js
@@ -4,7 +4,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import SocialMediaContainer from '../SocialMediaContainer';
 
 describe('SocialMediaContainer', () => {
-  it('it should render properly with required (all) props', () => {
+  it('should render with required props', () => {
     createSnapshotTest(
       <SocialMediaContainer>
         <div>Testing 1</div>

--- a/components/SocialMedia/SocialMediaContainer/__tests__/SocialMediaContainer.test.js
+++ b/components/SocialMedia/SocialMediaContainer/__tests__/SocialMediaContainer.test.js
@@ -4,7 +4,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import SocialMediaContainer from '../SocialMediaContainer';
 
 describe('SocialMediaContainer', () => {
-  test('it should render properly with required (all) props', () => {
+  it('it should render properly with required (all) props', () => {
     createSnapshotTest(
       <SocialMediaContainer>
         <div>Testing 1</div>

--- a/components/SocialMedia/SocialMediaContainer/__tests__/__snapshots__/SocialMediaContainer.test.js.snap
+++ b/components/SocialMedia/SocialMediaContainer/__tests__/__snapshots__/SocialMediaContainer.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SocialMediaContainer it should render properly with required (all) props 1`] = `
+exports[`SocialMediaContainer should render with required props 1`] = `
 <div
   className="SocialMediaContainer"
 >

--- a/components/SocialMedia/SocialMediaItem/__tests__/SocialMediaItem.test.js
+++ b/components/SocialMedia/SocialMediaItem/__tests__/SocialMediaItem.test.js
@@ -5,7 +5,7 @@ import FacebookLogo from 'static/images/icons/facebook_logo.svg';
 import SocialMediaItem from '../SocialMediaItem';
 
 describe('SocialMediaItem', () => {
-  it('it should render properly with required (all) props', () => {
+  it('should render with required props', () => {
     createSnapshotTest(
       <SocialMediaItem
         alt="Facebook"

--- a/components/SocialMedia/SocialMediaItem/__tests__/SocialMediaItem.test.js
+++ b/components/SocialMedia/SocialMediaItem/__tests__/SocialMediaItem.test.js
@@ -5,7 +5,7 @@ import FacebookLogo from 'static/images/icons/facebook_logo.svg';
 import SocialMediaItem from '../SocialMediaItem';
 
 describe('SocialMediaItem', () => {
-  test('it should render properly with required (all) props', () => {
+  it('it should render properly with required (all) props', () => {
     createSnapshotTest(
       <SocialMediaItem
         alt="Facebook"

--- a/components/SocialMedia/SocialMediaItem/__tests__/__snapshots__/SocialMediaItem.test.js.snap
+++ b/components/SocialMedia/SocialMediaItem/__tests__/__snapshots__/SocialMediaItem.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SocialMediaItem it should render properly with required (all) props 1`] = `
+exports[`SocialMediaItem should render with required props 1`] = `
 <div
   className="SocialMediaItem"
 >

--- a/components/SocialMedia/__tests__/SocialMedia.test.js
+++ b/components/SocialMedia/__tests__/SocialMedia.test.js
@@ -4,7 +4,7 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import SocialMedia from '../SocialMedia';
 
 describe('SocialMedia', () => {
-  it('it should render properly with no props', () => {
+  it('should render with no props passed passed', () => {
     createShallowSnapshotTest(<SocialMedia />);
   });
 });

--- a/components/SocialMedia/__tests__/SocialMedia.test.js
+++ b/components/SocialMedia/__tests__/SocialMedia.test.js
@@ -4,7 +4,7 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import SocialMedia from '../SocialMedia';
 
 describe('SocialMedia', () => {
-  test('it should render properly with no props', () => {
+  it('it should render properly with no props', () => {
     createShallowSnapshotTest(<SocialMedia />);
   });
 });

--- a/components/SocialMedia/__tests__/__snapshots__/SocialMedia.test.js.snap
+++ b/components/SocialMedia/__tests__/__snapshots__/SocialMedia.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SocialMedia it should render properly with no props 1`] = `
+exports[`SocialMedia should render with no props passed passed 1`] = `
 <SocialMediaContainer>
   <SocialMediaItem
     href="https://facebook.com/operationcode.org"

--- a/components/SuccessStory/__tests__/SuccessStory.test.js
+++ b/components/SuccessStory/__tests__/SuccessStory.test.js
@@ -4,7 +4,7 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import SuccessStory from '../SuccessStory';
 
 describe('SuccessStory', () => {
-  it('it should render properly with all required props', () => {
+  it('should render with required props', () => {
     createShallowSnapshotTest(
       <SuccessStory
         imageSource="image.png"

--- a/components/SuccessStory/__tests__/SuccessStory.test.js
+++ b/components/SuccessStory/__tests__/SuccessStory.test.js
@@ -4,7 +4,7 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import SuccessStory from '../SuccessStory';
 
 describe('SuccessStory', () => {
-  test('it should render properly with all required props', () => {
+  it('it should render properly with all required props', () => {
     createShallowSnapshotTest(
       <SuccessStory
         imageSource="image.png"

--- a/components/SuccessStory/__tests__/__snapshots__/SuccessStory.test.js.snap
+++ b/components/SuccessStory/__tests__/__snapshots__/SuccessStory.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SuccessStory it should render properly with all required props 1`] = `
+exports[`SuccessStory should render with required props 1`] = `
 <div
   className="SuccessStory"
 >

--- a/components/Timeline/TimelineEvent/__tests__/TimelineEvent.test.js
+++ b/components/Timeline/TimelineEvent/__tests__/TimelineEvent.test.js
@@ -4,7 +4,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import TimelineEvent from '../TimelineEvent';
 
 describe('TimelineEvent', () => {
-  it('should render properly with all required props', () => {
+  it('should render with required props', () => {
     createSnapshotTest(<TimelineEvent title="test title" content="here is some test content" />);
   });
 });

--- a/components/Timeline/TimelineEvent/__tests__/TimelineEvent.test.js
+++ b/components/Timeline/TimelineEvent/__tests__/TimelineEvent.test.js
@@ -4,7 +4,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import TimelineEvent from '../TimelineEvent';
 
 describe('TimelineEvent', () => {
-  test('should render properly with all required props', () => {
+  it('should render properly with all required props', () => {
     createSnapshotTest(<TimelineEvent title="test title" content="here is some test content" />);
   });
 });

--- a/components/Timeline/TimelineEvent/__tests__/__snapshots__/TimelineEvent.test.js.snap
+++ b/components/Timeline/TimelineEvent/__tests__/__snapshots__/TimelineEvent.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TimelineEvent should render properly with all required props 1`] = `
+exports[`TimelineEvent should render with required props 1`] = `
 <div
   className="eventContainer"
 >

--- a/components/Timeline/__tests__/Timeline.test.js
+++ b/components/Timeline/__tests__/Timeline.test.js
@@ -4,7 +4,7 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import Timeline from '../Timeline';
 
 describe('Timeline', () => {
-  test('it should render properly with no props', () => {
+  it('it should render properly with no props', () => {
     createShallowSnapshotTest(<Timeline />);
   });
 });

--- a/components/Timeline/__tests__/Timeline.test.js
+++ b/components/Timeline/__tests__/Timeline.test.js
@@ -4,7 +4,7 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import Timeline from '../Timeline';
 
 describe('Timeline', () => {
-  it('it should render properly with no props', () => {
+  it('should render with no props passed passed', () => {
     createShallowSnapshotTest(<Timeline />);
   });
 });

--- a/components/Timeline/__tests__/__snapshots__/Timeline.test.js.snap
+++ b/components/Timeline/__tests__/__snapshots__/Timeline.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Timeline it should render properly with no props 1`] = `
+exports[`Timeline should render with no props passed passed 1`] = `
 <div
   className="timeline"
 >

--- a/components/UpgradeBrowserOverlay/__tests__/UpgradeBrowserOverlay.test.js
+++ b/components/UpgradeBrowserOverlay/__tests__/UpgradeBrowserOverlay.test.js
@@ -5,7 +5,7 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import UpgradeBrowserOverlay from '../UpgradeBrowserOverlay';
 
 describe('UpgradeBrowserOverlay', () => {
-  it('should render with no props', () => {
+  it('should render with no props passed', () => {
     createShallowSnapshotTest(<UpgradeBrowserOverlay />);
   });
 });

--- a/components/UpgradeBrowserOverlay/__tests__/UpgradeBrowserOverlay.test.js
+++ b/components/UpgradeBrowserOverlay/__tests__/UpgradeBrowserOverlay.test.js
@@ -5,7 +5,7 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import UpgradeBrowserOverlay from '../UpgradeBrowserOverlay';
 
 describe('UpgradeBrowserOverlay', () => {
-  test('should render with no props', () => {
+  it('should render with no props', () => {
     createShallowSnapshotTest(<UpgradeBrowserOverlay />);
   });
 });

--- a/components/UpgradeBrowserOverlay/__tests__/__snapshots__/UpgradeBrowserOverlay.test.js.snap
+++ b/components/UpgradeBrowserOverlay/__tests__/__snapshots__/UpgradeBrowserOverlay.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UpgradeBrowserOverlay should render with no props 1`] = `
+exports[`UpgradeBrowserOverlay should render with no props passed 1`] = `
 <Modal
   className="UpgradeBrowserOverlay"
   hasCloseIcon={false}

--- a/components/_common_/Button/__tests__/Button.test.js
+++ b/components/_common_/Button/__tests__/Button.test.js
@@ -7,11 +7,11 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import Button from '../Button';
 
 describe('Button', () => {
-  test('should render with just required props passed', () => {
+  it('should render with just required props passed', () => {
     createSnapshotTest(<Button>Test</Button>);
   });
 
-  test('should render properly with some props assigned', () => {
+  it('should render properly with some props assigned', () => {
     createSnapshotTest(
       <Button theme="secondary" disabled fullWidth type="submit">
         Test
@@ -19,17 +19,17 @@ describe('Button', () => {
     );
   });
 
-  test('should spread data and aria props', () => {
+  it('should spread data and aria props', () => {
     const wrapper = shallow(
       <Button aria-label="test" data-attr="test">
         Test
       </Button>,
     );
-    expect(wrapper.prop('aria-label')).toEqual('test');
-    expect(wrapper.prop('data-attr')).toEqual('test');
+    expect(wrapper.prop('aria-label')).toStrictEqual('test');
+    expect(wrapper.prop('data-attr')).toStrictEqual('test');
   });
 
-  test('should render without a generated span when children is PropTypes.node', () => {
+  it('should render without a generated span when children is PropTypes.node', () => {
     const testText = 'Testing No Span';
 
     const ButtonInstance = mount(
@@ -45,18 +45,20 @@ describe('Button', () => {
           <b>{testText}</b>
         </span>,
       ]),
-    ).toEqual(false);
+    ).toStrictEqual(false);
   });
 
-  test('should render with a generated span when children is PropTypes.string', () => {
+  it('should render with a generated span when children is PropTypes.string', () => {
     const testText = 'Testing With Span';
 
     const ButtonInstance = mount(<Button>{testText}</Button>);
 
-    expect(ButtonInstance.containsAllMatchingElements([<span>{testText}</span>])).toEqual(true);
+    expect(ButtonInstance.containsAllMatchingElements([<span>{testText}</span>])).toStrictEqual(
+      true,
+    );
   });
 
-  test('should send log to console when clickHandler is called in non-prod environment', () => {
+  it('should send log to console when clickHandler is called in non-prod environment', () => {
     /* eslint-disable no-console */
     console.log = jest.fn();
 
@@ -64,11 +66,11 @@ describe('Button', () => {
 
     ButtonShallowInstance.instance().clickHandler();
 
-    expect(console.log.mock.calls.length).toEqual(1);
+    expect(console.log.mock.calls).toHaveLength(1);
     /* eslint-enable no-console */
   });
 
-  test('call props.onClick when button is clicked', () => {
+  it('call props.onClick when button is clicked', () => {
     const onClickMock = jest.fn();
     const ButtonShallowInstance = shallow(<Button onClick={onClickMock}>Test</Button>);
     ButtonShallowInstance.instance().clickHandler();
@@ -76,7 +78,7 @@ describe('Button', () => {
     expect(onClickMock).toHaveBeenCalledTimes(1);
   });
 
-  test('should call ReactGA when in prod environment', () => {
+  it('should call ReactGA when in prod environment', () => {
     /* eslint-disable no-console */
     ReactGA.initialize('foo', { testMode: true });
 

--- a/components/_common_/Button/__tests__/Button.test.js
+++ b/components/_common_/Button/__tests__/Button.test.js
@@ -7,26 +7,47 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import Button from '../Button';
 
 describe('Button', () => {
-  it('should render with just required props passed', () => {
+  it('should render with required props', () => {
     createSnapshotTest(<Button>Test</Button>);
   });
 
-  it('should render properly with some props assigned', () => {
+  it('should render with all props assigned', () => {
     createSnapshotTest(
-      <Button theme="secondary" disabled fullWidth type="submit">
+      <Button
+        analyticsObject={{ action: 'Test Button Selected', category: 'Testing' }}
+        className="test-class"
+        disabled
+        fullWidth
+        onClick={jest.fn()}
+        tabIndex={-1}
+        theme="secondary"
+        type="submit"
+        data-id="test-id"
+      >
         Test
       </Button>,
     );
   });
 
-  it('should spread data and aria props', () => {
-    const wrapper = shallow(
-      <Button aria-label="test" data-attr="test">
-        Test
-      </Button>,
-    );
-    expect(wrapper.prop('aria-label')).toStrictEqual('test');
-    expect(wrapper.prop('data-attr')).toStrictEqual('test');
+  it('should spread data- and aria- props', () => {
+    const ariaProp = 'aria-label';
+    const dataAttrProp = 'data-attr';
+
+    const testProps = { [`${ariaProp}`]: 'test', [`${dataAttrProp}`]: 'test-attr' };
+
+    const wrapper = shallow(<Button {...testProps}>Test</Button>);
+
+    expect(wrapper.prop(ariaProp)).toStrictEqual('test');
+    expect(wrapper.prop(dataAttrProp)).toStrictEqual('test-attr');
+  });
+
+  it('should should not spread an unexpected prop', () => {
+    const attribute = 'fakey-data-prop';
+    const testProps = { [`${attribute}`]: 'test' };
+
+    const wrapper = shallow(<Button {...testProps}>Test</Button>);
+
+    expect(wrapper.prop(attribute)).toBeUndefined();
   });
 
   it('should render without a generated span when children is PropTypes.node', () => {

--- a/components/_common_/Button/__tests__/__snapshots__/Button.test.js.snap
+++ b/components/_common_/Button/__tests__/__snapshots__/Button.test.js.snap
@@ -1,11 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Button should render properly with some props assigned 1`] = `
+exports[`Button should render with all props assigned 1`] = `
 <button
-  className="Button secondary disabled fullWidth"
+  className="Button test-class secondary disabled fullWidth"
+  data-id="test-id"
   disabled={true}
   onClick={[Function]}
-  tabIndex={0}
+  tabIndex={-1}
   type="submit"
 >
   <span>
@@ -14,7 +15,7 @@ exports[`Button should render properly with some props assigned 1`] = `
 </button>
 `;
 
-exports[`Button should render with just required props passed 1`] = `
+exports[`Button should render with required props 1`] = `
 <button
   className="Button primary"
   disabled={false}

--- a/components/_common_/Card/__tests__/Card.test.js
+++ b/components/_common_/Card/__tests__/Card.test.js
@@ -5,11 +5,11 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import Card from '../Card';
 
 describe('Card', () => {
-  test('should render with just required props passed', () => {
+  it('should render with just required props passed', () => {
     createSnapshotTest(<Card>Test</Card>);
   });
 
-  test('should render properly with some props assigned', () => {
+  it('should render properly with some props assigned', () => {
     createSnapshotTest(
       <Card className="test-class" hasAnimationOnHover>
         Test

--- a/components/_common_/Card/__tests__/Card.test.js
+++ b/components/_common_/Card/__tests__/Card.test.js
@@ -5,11 +5,11 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import Card from '../Card';
 
 describe('Card', () => {
-  it('should render with just required props passed', () => {
+  it('should render with required props', () => {
     createSnapshotTest(<Card>Test</Card>);
   });
 
-  it('should render properly with some props assigned', () => {
+  it('should render with all props assigned', () => {
     createSnapshotTest(
       <Card className="test-class" hasAnimationOnHover>
         Test

--- a/components/_common_/Card/__tests__/__snapshots__/Card.test.js.snap
+++ b/components/_common_/Card/__tests__/__snapshots__/Card.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Card should render properly with some props assigned 1`] = `
+exports[`Card should render with all props assigned 1`] = `
 <article
   className="Card test-class animatedCard"
 >
@@ -8,7 +8,7 @@ exports[`Card should render properly with some props assigned 1`] = `
 </article>
 `;
 
-exports[`Card should render with just required props passed 1`] = `
+exports[`Card should render with required props 1`] = `
 <article
   className="Card"
 >

--- a/components/_common_/CloseButton/__tests__/CloseButton.test.js
+++ b/components/_common_/CloseButton/__tests__/CloseButton.test.js
@@ -7,7 +7,7 @@ import CloseButton from '../CloseButton';
 const noOp = () => {};
 
 describe('CloseButton', () => {
-  it('should render with just required props passed', () => {
+  it('should render with required props', () => {
     createSnapshotTest(<CloseButton onClick={noOp} />);
   });
 

--- a/components/_common_/CloseButton/__tests__/__snapshots__/CloseButton.test.js.snap
+++ b/components/_common_/CloseButton/__tests__/__snapshots__/CloseButton.test.js.snap
@@ -13,7 +13,7 @@ exports[`CloseButton should render as disabled 1`] = `
 </button>
 `;
 
-exports[`CloseButton should render with just required props passed 1`] = `
+exports[`CloseButton should render with required props 1`] = `
 <button
   className="CloseButton"
   disabled={false}

--- a/components/_common_/Drawer/__tests__/Drawer.test.js
+++ b/components/_common_/Drawer/__tests__/Drawer.test.js
@@ -5,11 +5,11 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import Drawer from '../Drawer';
 
 describe('Drawer', () => {
-  it('should render with just required props passed', () => {
+  it('should render with required props', () => {
     createSnapshotTest(<Drawer>Test</Drawer>);
   });
 
-  it('should render properly with some props assigned', () => {
+  it('should render with all props assigned', () => {
     createSnapshotTest(
       <Drawer className="test-class" isVisible>
         Test

--- a/components/_common_/Drawer/__tests__/Drawer.test.js
+++ b/components/_common_/Drawer/__tests__/Drawer.test.js
@@ -5,11 +5,11 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import Drawer from '../Drawer';
 
 describe('Drawer', () => {
-  test('should render with just required props passed', () => {
+  it('should render with just required props passed', () => {
     createSnapshotTest(<Drawer>Test</Drawer>);
   });
 
-  test('should render properly with some props assigned', () => {
+  it('should render properly with some props assigned', () => {
     createSnapshotTest(
       <Drawer className="test-class" isVisible>
         Test

--- a/components/_common_/Drawer/__tests__/__snapshots__/Drawer.test.js.snap
+++ b/components/_common_/Drawer/__tests__/__snapshots__/Drawer.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Drawer should render properly with some props assigned 1`] = `
+exports[`Drawer should render with all props assigned 1`] = `
 <div
   className="test-class visible"
 >
@@ -12,7 +12,7 @@ exports[`Drawer should render properly with some props assigned 1`] = `
 </div>
 `;
 
-exports[`Drawer should render with just required props passed 1`] = `
+exports[`Drawer should render with required props 1`] = `
 <div
   className="hidden"
 >

--- a/components/_common_/Form/FormCheckBox/FormCheckBox.js
+++ b/components/_common_/Form/FormCheckBox/FormCheckBox.js
@@ -18,9 +18,9 @@ FormCheckBox.propTypes = {
 };
 
 FormCheckBox.defaultProps = {
-  checkBox: null,
-  label: null,
-  onChange: null,
+  checkBox: {},
+  label: {},
+  onChange: () => {},
 };
 
 function FormCheckBox({ checkBox, label, name, onChange, value }) {

--- a/components/_common_/Form/FormCheckBox/__tests__/FormCheckBox.test.js
+++ b/components/_common_/Form/FormCheckBox/__tests__/FormCheckBox.test.js
@@ -5,18 +5,18 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import FormCheckBox from '../FormCheckBox';
 
 describe('FormCheckBox', () => {
-  it('should render with just required props passed', () => {
+  it('should render with required props', () => {
     createSnapshotTest(<FormCheckBox>Test</FormCheckBox>);
   });
 
-  it('should render properly with some props assigned', () => {
+  it('should render with all props assigned', () => {
     createSnapshotTest(
       <FormCheckBox
-        className="somename"
-        data-custom-attr="custom stuff here"
-        disabled
-        fullWidth
-        type="checkbox"
+        checkBox={{ display: 'inline-block', margin: '1rem' }}
+        label={{ fontWeight: 'bold', margin: '1rem', textTransform: 'uppercase' }}
+        name="test-checkbox"
+        onChange={jest.fn()}
+        value="test value"
       >
         Test
       </FormCheckBox>,

--- a/components/_common_/Form/FormCheckBox/__tests__/FormCheckBox.test.js
+++ b/components/_common_/Form/FormCheckBox/__tests__/FormCheckBox.test.js
@@ -5,11 +5,11 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import FormCheckBox from '../FormCheckBox';
 
 describe('FormCheckBox', () => {
-  test('should render with just required props passed', () => {
+  it('should render with just required props passed', () => {
     createSnapshotTest(<FormCheckBox>Test</FormCheckBox>);
   });
 
-  test('should render properly with some props assigned', () => {
+  it('should render properly with some props assigned', () => {
     createSnapshotTest(
       <FormCheckBox
         className="somename"

--- a/components/_common_/Form/FormCheckBox/__tests__/__snapshots__/FormCheckBox.test.js.snap
+++ b/components/_common_/Form/FormCheckBox/__tests__/__snapshots__/FormCheckBox.test.js.snap
@@ -1,31 +1,48 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FormCheckBox should render properly with some props assigned 1`] = `
+exports[`FormCheckBox should render with all props assigned 1`] = `
 <div
-  style={null}
+  style={
+    Object {
+      "display": "inline-block",
+      "margin": "1rem",
+    }
+  }
 >
   <input
     className="input"
-    onChange={null}
+    id="test value"
+    name="test-checkbox"
+    onChange={[MockFunction]}
     type="checkbox"
+    value="test value"
   />
   <label
-    style={null}
-  />
+    htmlFor="test-checkbox"
+    style={
+      Object {
+        "fontWeight": "bold",
+        "margin": "1rem",
+        "textTransform": "uppercase",
+      }
+    }
+  >
+    test value
+  </label>
 </div>
 `;
 
-exports[`FormCheckBox should render with just required props passed 1`] = `
+exports[`FormCheckBox should render with required props 1`] = `
 <div
-  style={null}
+  style={Object {}}
 >
   <input
     className="input"
-    onChange={null}
+    onChange={[Function]}
     type="checkbox"
   />
   <label
-    style={null}
+    style={Object {}}
   />
 </div>
 `;

--- a/components/_common_/Form/FormEmail/__tests__/FormEmail.test.js
+++ b/components/_common_/Form/FormEmail/__tests__/FormEmail.test.js
@@ -5,7 +5,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import FormEmail from '../FormEmail';
 
 describe('FormEmail', () => {
-  it('should render with just required props passed', () => {
+  it('should render with required props', () => {
     createSnapshotTest(<FormEmail id="test" />);
   });
 });

--- a/components/_common_/Form/FormEmail/__tests__/FormEmail.test.js
+++ b/components/_common_/Form/FormEmail/__tests__/FormEmail.test.js
@@ -5,7 +5,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import FormEmail from '../FormEmail';
 
 describe('FormEmail', () => {
-  test('should render with just required props passed', () => {
+  it('should render with just required props passed', () => {
     createSnapshotTest(<FormEmail id="test" />);
   });
 });

--- a/components/_common_/Form/FormEmail/__tests__/__snapshots__/FormEmail.test.js.snap
+++ b/components/_common_/Form/FormEmail/__tests__/__snapshots__/FormEmail.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FormEmail should render with just required props passed 1`] = `
+exports[`FormEmail should render with required props 1`] = `
 <div
   className="formInput"
 >

--- a/components/_common_/Form/FormInput/__tests__/FormInput.test.js
+++ b/components/_common_/Form/FormInput/__tests__/FormInput.test.js
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import FormInput from '../FormInput';
 
 describe('FormInput', () => {
-  it('should render with just required props passed', () => {
+  it('should render with required props', () => {
     createSnapshotTest(<FormInput id="test" />);
   });
 

--- a/components/_common_/Form/FormInput/__tests__/FormInput.test.js
+++ b/components/_common_/Form/FormInput/__tests__/FormInput.test.js
@@ -6,15 +6,15 @@ import { mount } from 'enzyme';
 import FormInput from '../FormInput';
 
 describe('FormInput', () => {
-  test('should render with just required props passed', () => {
+  it('should render with just required props passed', () => {
     createSnapshotTest(<FormInput id="test" />);
   });
 
-  test('should render with label', () => {
+  it('should render with label', () => {
     createSnapshotTest(<FormInput id="test" label="Testinput" />);
   });
 
-  test('should call onChange from props after onChange', () => {
+  it('should call onChange from props after onChange', () => {
     const onChangeMock = jest.fn();
     const wrap = mount(<FormInput onChange={onChangeMock} id="test" />);
     wrap.find('input').simulate('change', {
@@ -24,7 +24,7 @@ describe('FormInput', () => {
     expect(onChangeMock).toBeCalledWith('Test', true);
   });
 
-  test('should show error onChange if value is empty', () => {
+  it('should show error onChange if value is empty', () => {
     const validationErrorMessage = 'invalid input';
     const wrap = mount(<FormInput validationErrorMessage={validationErrorMessage} id="test" />);
     wrap.find('input').simulate('change', {
@@ -33,7 +33,7 @@ describe('FormInput', () => {
     expect(wrap.find('span').text()).toBe(validationErrorMessage);
   });
 
-  test('should show no error onChange if value is not empty', () => {
+  it('should show no error onChange if value is not empty', () => {
     const validationErrorMessage = 'invalid input';
     const wrap = mount(<FormInput validationErrorMessage={validationErrorMessage} id="test" />);
     wrap.find('input').simulate('change', {
@@ -42,7 +42,7 @@ describe('FormInput', () => {
     expect(wrap.exists('span')).toBe(false);
   });
 
-  test('should show error onChange if error with validateFunc', () => {
+  it('should show error onChange if error with validateFunc', () => {
     const validationErrorMessage = 'invalid input';
     const inputShouldContainString = 'Teststring1234';
     const wrap = mount(
@@ -64,7 +64,7 @@ describe('FormInput', () => {
     expect(wrap.exists('span')).toBe(false);
   });
 
-  test('should show error onChange if error with validationRegex', () => {
+  it('should show error onChange if error with validationRegex', () => {
     const validationErrorMessage = 'invalid input';
     const validationRegex = new RegExp('^Test');
     const wrap = mount(

--- a/components/_common_/Form/FormInput/__tests__/__snapshots__/FormInput.test.js.snap
+++ b/components/_common_/Form/FormInput/__tests__/__snapshots__/FormInput.test.js.snap
@@ -1,9 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FormInput should render with just required props passed 1`] = `
+exports[`FormInput should render with label 1`] = `
 <div
   className="formInput"
 >
+  <label
+    htmlFor="test"
+  >
+    Testinput
+  </label>
   <input
     id="test"
     onChange={[Function]}
@@ -14,15 +19,10 @@ exports[`FormInput should render with just required props passed 1`] = `
 </div>
 `;
 
-exports[`FormInput should render with label 1`] = `
+exports[`FormInput should render with required props 1`] = `
 <div
   className="formInput"
 >
-  <label
-    htmlFor="test"
-  >
-    Testinput
-  </label>
   <input
     id="test"
     onChange={[Function]}

--- a/components/_common_/Form/FormPassword/__tests__/FormPassword.test.js
+++ b/components/_common_/Form/FormPassword/__tests__/FormPassword.test.js
@@ -5,7 +5,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import FormPassword from '../FormPassword';
 
 describe('FormPassword', () => {
-  it('should render with just required props passed', () => {
+  it('should render with required props', () => {
     createSnapshotTest(<FormPassword id="test" />);
   });
 });

--- a/components/_common_/Form/FormPassword/__tests__/FormPassword.test.js
+++ b/components/_common_/Form/FormPassword/__tests__/FormPassword.test.js
@@ -5,7 +5,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import FormPassword from '../FormPassword';
 
 describe('FormPassword', () => {
-  test('should render with just required props passed', () => {
+  it('should render with just required props passed', () => {
     createSnapshotTest(<FormPassword id="test" />);
   });
 });

--- a/components/_common_/Form/FormPassword/__tests__/__snapshots__/FormPassword.test.js.snap
+++ b/components/_common_/Form/FormPassword/__tests__/__snapshots__/FormPassword.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FormPassword should render with just required props passed 1`] = `
+exports[`FormPassword should render with required props 1`] = `
 <div
   className="formInput"
 >

--- a/components/_common_/Form/FormSelect/__tests__/FormSelect.test.js
+++ b/components/_common_/Form/FormSelect/__tests__/FormSelect.test.js
@@ -12,15 +12,15 @@ describe('FormSelect', () => {
     options = [{ label: 'test 1', value: 'TEST1' }, { label: 'test 2', value: 'TEST2' }];
   });
 
-  test('should render with just required props passed', () => {
+  it('should render with just required props passed', () => {
     createSnapshotTest(<FormSelect options={options} />);
   });
 
-  test('should render when passed a prompt and options', () => {
+  it('should render when passed a prompt and options', () => {
     createSnapshotTest(<FormSelect options={options} prompt="Select an item" />);
   });
 
-  test('should call onChange from props after onChange', () => {
+  it('should call onChange from props after onChange', () => {
     const onChangeMock = jest.fn();
     const wrap = mount(<FormSelect onChange={onChangeMock} options={options} />);
     wrap.find('select').simulate('change', {
@@ -32,7 +32,7 @@ describe('FormSelect', () => {
     expect(onChangeMock).toBeCalledWith('TEST1');
   });
 
-  test('should call onChange from props after onChange with validate', () => {
+  it('should call onChange from props after onChange with validate', () => {
     const onChangeMock = jest.fn();
     const wrap = mount(
       <FormSelect

--- a/components/_common_/Form/FormSelect/__tests__/FormSelect.test.js
+++ b/components/_common_/Form/FormSelect/__tests__/FormSelect.test.js
@@ -12,7 +12,7 @@ describe('FormSelect', () => {
     options = [{ label: 'test 1', value: 'TEST1' }, { label: 'test 2', value: 'TEST2' }];
   });
 
-  it('should render with just required props passed', () => {
+  it('should render with required props', () => {
     createSnapshotTest(<FormSelect options={options} />);
   });
 

--- a/components/_common_/Form/FormSelect/__tests__/__snapshots__/FormSelect.test.js.snap
+++ b/components/_common_/Form/FormSelect/__tests__/__snapshots__/FormSelect.test.js.snap
@@ -29,7 +29,7 @@ exports[`FormSelect should render when passed a prompt and options 1`] = `
 </div>
 `;
 
-exports[`FormSelect should render with just required props passed 1`] = `
+exports[`FormSelect should render with required props 1`] = `
 <div>
   <select
     id=""

--- a/components/_common_/Form/FormTextArea/__tests__/FormTextArea.test.js
+++ b/components/_common_/Form/FormTextArea/__tests__/FormTextArea.test.js
@@ -6,15 +6,15 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import FormTextArea from '../FormTextArea';
 
 describe('FormTextArea', () => {
-  test('should render with just required props passed', () => {
+  it('should render with just required props passed', () => {
     createSnapshotTest(<FormTextArea />);
   });
 
-  test('should render when passed a placeholder', () => {
+  it('should render when passed a placeholder', () => {
     createSnapshotTest(<FormTextArea placeholder="testplaceholder" />);
   });
 
-  test('should call onChange function when text is changed in textarea', () => {
+  it('should call onChange function when text is changed in textarea', () => {
     const props = { onChange: jest.fn() };
     const event = { target: { value: 'TestText' } };
 

--- a/components/_common_/Form/FormTextArea/__tests__/FormTextArea.test.js
+++ b/components/_common_/Form/FormTextArea/__tests__/FormTextArea.test.js
@@ -6,7 +6,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import FormTextArea from '../FormTextArea';
 
 describe('FormTextArea', () => {
-  it('should render with just required props passed', () => {
+  it('should render with required props', () => {
     createSnapshotTest(<FormTextArea />);
   });
 

--- a/components/_common_/Form/FormTextArea/__tests__/__snapshots__/FormTextArea.test.js.snap
+++ b/components/_common_/Form/FormTextArea/__tests__/__snapshots__/FormTextArea.test.js.snap
@@ -10,7 +10,7 @@ exports[`FormTextArea should render when passed a placeholder 1`] = `
 </div>
 `;
 
-exports[`FormTextArea should render with just required props passed 1`] = `
+exports[`FormTextArea should render with required props 1`] = `
 <div>
   <textarea
     className="text_area"

--- a/components/_common_/Form/FormZipCode/__tests__/FormZipCode.test.js
+++ b/components/_common_/Form/FormZipCode/__tests__/FormZipCode.test.js
@@ -5,7 +5,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import FormZipCode from '../FormZipCode';
 
 describe('FormZipCode', () => {
-  it('should render with just required props passed', () => {
+  it('should render with required props', () => {
     createSnapshotTest(<FormZipCode />);
   });
 });

--- a/components/_common_/Form/FormZipCode/__tests__/FormZipCode.test.js
+++ b/components/_common_/Form/FormZipCode/__tests__/FormZipCode.test.js
@@ -5,7 +5,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import FormZipCode from '../FormZipCode';
 
 describe('FormZipCode', () => {
-  test('should render with just required props passed', () => {
+  it('should render with just required props passed', () => {
     createSnapshotTest(<FormZipCode />);
   });
 });

--- a/components/_common_/Form/FormZipCode/__tests__/__snapshots__/FormZipCode.test.js.snap
+++ b/components/_common_/Form/FormZipCode/__tests__/__snapshots__/FormZipCode.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FormZipCode should render with just required props passed 1`] = `
+exports[`FormZipCode should render with required props 1`] = `
 <div
   className="formInput"
 >

--- a/components/_common_/Form/__tests__/Form.test.js
+++ b/components/_common_/Form/__tests__/Form.test.js
@@ -5,18 +5,18 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import Form from 'components/_common_/Form/Form';
 
 describe('Form', () => {
-  it('should render with just required props passed', () => {
+  it('should render with required props', () => {
     createSnapshotTest(
       <Form>
-        <div />
+        <p>Test</p>
       </Form>,
     );
   });
 
-  it('should render properly with some props assigned', () => {
+  it('should render with all props assigned', () => {
     createSnapshotTest(
       <Form className="login-form">
-        <div />
+        <p>Test</p>
       </Form>,
     );
   });

--- a/components/_common_/Form/__tests__/Form.test.js
+++ b/components/_common_/Form/__tests__/Form.test.js
@@ -5,7 +5,7 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import Form from 'components/_common_/Form/Form';
 
 describe('Form', () => {
-  test('should render with just required props passed', () => {
+  it('should render with just required props passed', () => {
     createSnapshotTest(
       <Form>
         <div />
@@ -13,7 +13,7 @@ describe('Form', () => {
     );
   });
 
-  test('should render properly with some props assigned', () => {
+  it('should render properly with some props assigned', () => {
     createSnapshotTest(
       <Form className="login-form">
         <div />

--- a/components/_common_/Form/__tests__/__snapshots__/Form.test.js.snap
+++ b/components/_common_/Form/__tests__/__snapshots__/Form.test.js.snap
@@ -1,17 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Form should render properly with some props assigned 1`] = `
+exports[`Form should render with all props assigned 1`] = `
 <form
   className="form login-form"
 >
-  <div />
+  <p>
+    Test
+  </p>
 </form>
 `;
 
-exports[`Form should render with just required props passed 1`] = `
+exports[`Form should render with required props 1`] = `
 <form
   className="form"
 >
-  <div />
+  <p>
+    Test
+  </p>
 </form>
 `;

--- a/components/_common_/Heading/__tests__/Heading.test.js
+++ b/components/_common_/Heading/__tests__/Heading.test.js
@@ -6,13 +6,13 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import Heading from '../Heading';
 
 describe('Heading', () => {
-  it('should render with just required props passed', () => {
+  it('should render with required props', () => {
     createSnapshotTest(<Heading>Test</Heading>);
   });
 
-  it('should render properly with some props assigned', () => {
+  it('should render with all props assigned', () => {
     createSnapshotTest(
-      <Heading className="test-class" id="test-heading-1" hasHeadingLines={false}>
+      <Heading className="test-class" id="test-heading-1" hasHeadingLines={false} theme="slate">
         Test
       </Heading>,
     );

--- a/components/_common_/Heading/__tests__/Heading.test.js
+++ b/components/_common_/Heading/__tests__/Heading.test.js
@@ -6,11 +6,11 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import Heading from '../Heading';
 
 describe('Heading', () => {
-  test('should render with just required props passed', () => {
+  it('should render with just required props passed', () => {
     createSnapshotTest(<Heading>Test</Heading>);
   });
 
-  test('should render properly with some props assigned', () => {
+  it('should render properly with some props assigned', () => {
     createSnapshotTest(
       <Heading className="test-class" id="test-heading-1" hasHeadingLines={false}>
         Test
@@ -18,13 +18,13 @@ describe('Heading', () => {
     );
   });
 
-  test('should render with "slate" in classNames when theme="slate"', () => {
+  it('should render with "slate" in classNames when theme="slate"', () => {
     const HeaderInstance = shallow(<Heading theme="slate">Test</Heading>);
 
     expect(HeaderInstance).toHaveClassName('slate');
   });
 
-  test('should render without "headingLines" in classNames when hasHeadingLines={false}', () => {
+  it('should render without "headingLines" in classNames when hasHeadingLines={false}', () => {
     const HeaderInstance = shallow(<Heading hasHeadingLines={false}>Test</Heading>);
 
     expect(HeaderInstance).not.toHaveClassName('headingLines');

--- a/components/_common_/Heading/__tests__/__snapshots__/Heading.test.js.snap
+++ b/components/_common_/Heading/__tests__/__snapshots__/Heading.test.js.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Heading should render properly with some props assigned 1`] = `
+exports[`Heading should render with all props assigned 1`] = `
 <h2
-  className="test-class Heading gray"
+  className="test-class Heading slate"
   id="test-heading-1"
 >
   Test
 </h2>
 `;
 
-exports[`Heading should render with just required props passed 1`] = `
+exports[`Heading should render with required props 1`] = `
 <h2
   className="Heading gray headingLines"
   id=""

--- a/components/_common_/HeroBanner/__tests__/HeroBanner.test.js
+++ b/components/_common_/HeroBanner/__tests__/HeroBanner.test.js
@@ -11,26 +11,26 @@ import HeroBanner from '../HeroBanner';
 describe('HeroBanner', () => {
   const testImageUrl = `${s3}heroBanner/stock_family-2.jpg`;
 
-  test('should render with just required props passed', () => {
+  it('should render with just required props passed', () => {
     createSnapshotTest(<HeroBanner title="Test" imageSource={testImageUrl} />);
   });
 
-  test('should render properly with all props assigned', () => {
+  it('should render properly with all props assigned', () => {
     createSnapshotTest(
       <HeroBanner className="testing-123" title="Test" imageSource={testImageUrl}>
         Testing 123
       </HeroBanner>,
     );
   });
-  test('should have "fullViewHeight" class when passed isFullViewHeight', () => {
+  it('should have "fullViewHeight" class when passed isFullViewHeight', () => {
     const wrapper = mount(<HeroBanner title="Test" imageSource={testImageUrl} isFullViewHeight />);
 
-    expect(wrapper.find('.HeroBanner').hasClass('fullViewHeight')).toEqual(true);
+    expect(wrapper.find('.HeroBanner').hasClass('fullViewHeight')).toStrictEqual(true);
   });
 
-  test('should NOT have "fullViewHeight" class when NOT passed isFullViewHeight', () => {
+  it('should NOT have "fullViewHeight" class when NOT passed isFullViewHeight', () => {
     const wrapper = mount(<HeroBanner title="Test" imageSource={testImageUrl} />);
 
-    expect(wrapper.find('.HeroBanner').hasClass('fullViewHeight')).toEqual(false);
+    expect(wrapper.find('.HeroBanner').hasClass('fullViewHeight')).toStrictEqual(false);
   });
 });

--- a/components/_common_/HeroBanner/__tests__/HeroBanner.test.js
+++ b/components/_common_/HeroBanner/__tests__/HeroBanner.test.js
@@ -11,17 +11,18 @@ import HeroBanner from '../HeroBanner';
 describe('HeroBanner', () => {
   const testImageUrl = `${s3}heroBanner/stock_family-2.jpg`;
 
-  it('should render with just required props passed', () => {
+  it('should render with required props', () => {
     createSnapshotTest(<HeroBanner title="Test" imageSource={testImageUrl} />);
   });
 
-  it('should render properly with all props assigned', () => {
+  it('should render with all props assigned', () => {
     createSnapshotTest(
       <HeroBanner className="testing-123" title="Test" imageSource={testImageUrl}>
         Testing 123
       </HeroBanner>,
     );
   });
+
   it('should have "fullViewHeight" class when passed isFullViewHeight', () => {
     const wrapper = mount(<HeroBanner title="Test" imageSource={testImageUrl} isFullViewHeight />);
 

--- a/components/_common_/HeroBanner/__tests__/__snapshots__/HeroBanner.test.js.snap
+++ b/components/_common_/HeroBanner/__tests__/__snapshots__/HeroBanner.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HeroBanner should render properly with all props assigned 1`] = `
+exports[`HeroBanner should render with all props assigned 1`] = `
 <div
   className="testing-123 HeroBanner"
   style={
@@ -22,7 +22,7 @@ exports[`HeroBanner should render properly with all props assigned 1`] = `
 </div>
 `;
 
-exports[`HeroBanner should render with just required props passed 1`] = `
+exports[`HeroBanner should render with required props 1`] = `
 <div
   className="HeroBanner"
   style={

--- a/components/_common_/Modal/Modal.js
+++ b/components/_common_/Modal/Modal.js
@@ -12,7 +12,7 @@ Modal.propTypes = {
   className: PropTypes.string,
   hasCloseIcon: PropTypes.bool,
   isOpen: PropTypes.bool,
-  onRequestClose: PropTypes.func,
+  onRequestClose: PropTypes.func.isRequired,
   screenReaderLabel: PropTypes.string.isRequired, // basically a summarizing title
   shouldCloseOnOverlayClick: PropTypes.bool,
 };
@@ -21,7 +21,6 @@ Modal.defaultProps = {
   className: '',
   hasCloseIcon: true,
   isOpen: false,
-  onRequestClose: undefined,
   shouldCloseOnOverlayClick: true,
 };
 

--- a/components/_common_/Modal/__tests__/Modal.test.js
+++ b/components/_common_/Modal/__tests__/Modal.test.js
@@ -8,7 +8,7 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import Modal from '../Modal';
 
 describe('Modal', () => {
-  test('should render with just required props passed', () => {
+  it('should render with just required props passed', () => {
     createSnapshotTest(
       <Modal screenReaderLabel="Test" onRequestClose={() => {}}>
         Test
@@ -16,7 +16,7 @@ describe('Modal', () => {
     );
   });
 
-  test('should render properly with some props assigned and not being open', () => {
+  it('should render properly with some props assigned and not being open', () => {
     createSnapshotTest(
       <Modal
         className="test-class"
@@ -29,7 +29,7 @@ describe('Modal', () => {
     );
   });
 
-  test('should render properly with some props assigned and being open', () => {
+  it('should render properly with some props assigned and being open', () => {
     createShallowSnapshotTest(
       <Modal
         className="test-class"
@@ -43,7 +43,7 @@ describe('Modal', () => {
     );
   });
 
-  test('should call ReactGA when in prod environment', () => {
+  it('should call ReactGA when in prod environment', () => {
     ReactGA.initialize('foo', { testMode: true });
 
     process.env.NODE_ENV = 'production';

--- a/components/_common_/Modal/__tests__/Modal.test.js
+++ b/components/_common_/Modal/__tests__/Modal.test.js
@@ -3,40 +3,27 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import ReactGA from 'react-ga';
 import createSnapshotTest from 'test-utils/createSnapshotTest';
-import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 
 import Modal from '../Modal';
 
 describe('Modal', () => {
-  it('should render with just required props passed', () => {
+  it('should render with required props', () => {
     createSnapshotTest(
-      <Modal screenReaderLabel="Test" onRequestClose={() => {}}>
+      <Modal screenReaderLabel="Test" onRequestClose={jest.fn()}>
         Test
       </Modal>,
     );
   });
 
-  it('should render properly with some props assigned and not being open', () => {
+  it('should render with all props assigned', () => {
     createSnapshotTest(
       <Modal
         className="test-class"
-        onRequestClose={() => {}}
-        screenReaderLabel="Test"
-        shouldCloseOnOverlayClick
-      >
-        Test
-      </Modal>,
-    );
-  });
-
-  it('should render properly with some props assigned and being open', () => {
-    createShallowSnapshotTest(
-      <Modal
-        className="test-class"
+        hasCloseIcon={false}
         isOpen
-        onRequestClose={() => {}}
+        onRequestClose={jest.fn()}
         screenReaderLabel="Test"
-        shouldCloseOnOverlayClick
+        shouldCloseOnOverlayClick={false}
       >
         Test
       </Modal>,

--- a/components/_common_/Modal/__tests__/__snapshots__/Modal.test.js.snap
+++ b/components/_common_/Modal/__tests__/__snapshots__/Modal.test.js.snap
@@ -1,34 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Modal should render properly with some props assigned and being open 1`] = `
-<Modal
-  ariaHideApp={true}
-  bodyOpenClassName="ReactModal__Body--open"
-  className="Card ModalCard test-class"
-  closeTimeoutMS={0}
-  contentLabel="Test"
-  isOpen={true}
-  onRequestClose={[Function]}
-  parentSelector={[MockFunction]}
-  portalClassName="ReactModalPortal"
-  role="dialog"
-  shouldCloseOnEsc={true}
-  shouldCloseOnOverlayClick={true}
-  shouldFocusAfterRender={true}
-  shouldReturnFocusAfterClose={true}
->
-  <CloseButton
-    disabled={false}
-    onClick={[Function]}
-  />
-  <div
-    className="scrollableContainer"
-  >
-    Test
-  </div>
-</Modal>
-`;
+exports[`Modal should render with all props assigned 1`] = `null`;
 
-exports[`Modal should render properly with some props assigned and not being open 1`] = `null`;
-
-exports[`Modal should render with just required props passed 1`] = `null`;
+exports[`Modal should render with required props 1`] = `null`;

--- a/components/_common_/OutboundLink/__tests__/OutboundLink.test.js
+++ b/components/_common_/OutboundLink/__tests__/OutboundLink.test.js
@@ -8,7 +8,7 @@ import ReactGA from 'react-ga';
 import OutboundLink from '../OutboundLink';
 
 describe('OutboundLink', () => {
-  test('should render with just required props passed', () => {
+  it('should render with just required props passed', () => {
     createSnapshotTest(
       <OutboundLink analyticsEventLabel="Test" href="https://tests.com">
         Test
@@ -16,7 +16,7 @@ describe('OutboundLink', () => {
     );
   });
 
-  test('should render properly with all props assigned', () => {
+  it('should render properly with all props assigned', () => {
     createSnapshotTest(
       <OutboundLink
         analyticsEventLabel="Test"
@@ -29,7 +29,7 @@ describe('OutboundLink', () => {
     );
   });
 
-  test('should render ReactGA.OutboundLink when in prod environment', () => {
+  it('should render ReactGA.OutboundLink when in prod environment', () => {
     ReactGA.initialize('foo', { testMode: true });
 
     process.env.NODE_ENV = 'production';
@@ -46,6 +46,6 @@ describe('OutboundLink', () => {
       </OutboundLink>,
     );
 
-    expect(OutboundLinkShallowInstance.find('OutboundLink').length).toEqual(1);
+    expect(OutboundLinkShallowInstance.find('OutboundLink')).toHaveLength(1);
   });
 });

--- a/components/_common_/OutboundLink/__tests__/OutboundLink.test.js
+++ b/components/_common_/OutboundLink/__tests__/OutboundLink.test.js
@@ -8,7 +8,7 @@ import ReactGA from 'react-ga';
 import OutboundLink from '../OutboundLink';
 
 describe('OutboundLink', () => {
-  it('should render with just required props passed', () => {
+  it('should render with required props', () => {
     createSnapshotTest(
       <OutboundLink analyticsEventLabel="Test" href="https://tests.com">
         Test
@@ -16,7 +16,7 @@ describe('OutboundLink', () => {
     );
   });
 
-  it('should render properly with all props assigned', () => {
+  it('should render with all props assigned', () => {
     createSnapshotTest(
       <OutboundLink
         analyticsEventLabel="Test"

--- a/components/_common_/OutboundLink/__tests__/__snapshots__/OutboundLink.test.js.snap
+++ b/components/_common_/OutboundLink/__tests__/__snapshots__/OutboundLink.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OutboundLink should render properly with all props assigned 1`] = `
+exports[`OutboundLink should render with all props assigned 1`] = `
 <a
   className="test-class"
   href="https://tests.com"
@@ -16,7 +16,7 @@ exports[`OutboundLink should render properly with all props assigned 1`] = `
 </a>
 `;
 
-exports[`OutboundLink should render with just required props passed 1`] = `
+exports[`OutboundLink should render with required props 1`] = `
 <a
   className=""
   href="https://tests.com"

--- a/components/_common_/ScrollButton/ScrollButton.js
+++ b/components/_common_/ScrollButton/ScrollButton.js
@@ -19,7 +19,7 @@ class ScrollButton extends Component {
   static defaultProps = {
     className: '',
     fullWidth: false,
-    onClick: undefined,
+    onClick: () => {},
     tabIndex: 0,
     theme: 'primary',
   };

--- a/components/_common_/ScrollButton/__tests__/ScrollButton.test.js
+++ b/components/_common_/ScrollButton/__tests__/ScrollButton.test.js
@@ -7,13 +7,20 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import ScrollButton from '../ScrollButton';
 
 describe('ScrollButton', () => {
-  it('should render with just required props passed', () => {
+  it('should render with required props', () => {
     createSnapshotTest(<ScrollButton href="#test">Test</ScrollButton>);
   });
 
-  it('should render properly with some props assigned', () => {
+  it('should render with all props assigned', () => {
     createSnapshotTest(
-      <ScrollButton disabled fullWidth href="#test" theme="secondary" type="submit">
+      <ScrollButton
+        className="test"
+        fullWidth
+        href="#test"
+        onClick={jest.fn()}
+        tabIndex={-1}
+        theme="secondary"
+      >
         Test
       </ScrollButton>,
     );

--- a/components/_common_/ScrollButton/__tests__/ScrollButton.test.js
+++ b/components/_common_/ScrollButton/__tests__/ScrollButton.test.js
@@ -7,11 +7,11 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import ScrollButton from '../ScrollButton';
 
 describe('ScrollButton', () => {
-  test('should render with just required props passed', () => {
+  it('should render with just required props passed', () => {
     createSnapshotTest(<ScrollButton href="#test">Test</ScrollButton>);
   });
 
-  test('should render properly with some props assigned', () => {
+  it('should render properly with some props assigned', () => {
     createSnapshotTest(
       <ScrollButton disabled fullWidth href="#test" theme="secondary" type="submit">
         Test
@@ -19,7 +19,7 @@ describe('ScrollButton', () => {
     );
   });
 
-  test('should render without a generated span when children is PropTypes.node', () => {
+  it('should render without a generated span when children is PropTypes.node', () => {
     const testText = 'Testing No Span';
 
     const ScrollButtonInstance = mount(
@@ -35,20 +35,20 @@ describe('ScrollButton', () => {
           <b>{testText}</b>
         </span>,
       ]),
-    ).toEqual(false);
+    ).toStrictEqual(false);
   });
 
-  test('should render with a generated span when children is PropTypes.string', () => {
+  it('should render with a generated span when children is PropTypes.string', () => {
     const testText = 'Testing With Span';
 
     const ScrollButtonInstance = mount(<ScrollButton href="#test">{testText}</ScrollButton>);
 
-    expect(ScrollButtonInstance.containsAllMatchingElements([<span>{testText}</span>])).toEqual(
-      true,
-    );
+    expect(
+      ScrollButtonInstance.containsAllMatchingElements([<span>{testText}</span>]),
+    ).toStrictEqual(true);
   });
 
-  test('should send log to console when clickHandler is called in non-prod environment', () => {
+  it('should send log to console when clickHandler is called in non-prod environment', () => {
     /* eslint-disable no-console */
     console.log = jest.fn();
 
@@ -56,11 +56,11 @@ describe('ScrollButton', () => {
 
     ScrollButtonShallowInstance.instance().clickHandler();
 
-    expect(console.log.mock.calls.length).toEqual(1);
+    expect(console.log.mock.calls).toHaveLength(1);
     /* eslint-enable no-console */
   });
 
-  test('should call ReactGA when in prod environment', () => {
+  it('should call ReactGA when in prod environment', () => {
     /* eslint-disable no-console */
     ReactGA.initialize('foo', { testMode: true });
 

--- a/components/_common_/ScrollButton/__tests__/__snapshots__/ScrollButton.test.js.snap
+++ b/components/_common_/ScrollButton/__tests__/__snapshots__/ScrollButton.test.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ScrollButton should render properly with some props assigned 1`] = `
+exports[`ScrollButton should render with all props assigned 1`] = `
 <a
-  className="Button secondary fullWidth"
+  className="Button test secondary fullWidth"
   onClick={[Function]}
-  tabIndex={0}
+  tabIndex={-1}
 >
   <span>
     Test
@@ -12,7 +12,7 @@ exports[`ScrollButton should render properly with some props assigned 1`] = `
 </a>
 `;
 
-exports[`ScrollButton should render with just required props passed 1`] = `
+exports[`ScrollButton should render with required props 1`] = `
 <a
   className="Button primary"
   onClick={[Function]}

--- a/components/_common_/Section/__tests__/Section.test.js
+++ b/components/_common_/Section/__tests__/Section.test.js
@@ -5,11 +5,11 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import Section from '../Section';
 
 describe('Section', () => {
-  it('should render with just required props passed', () => {
+  it('should render with required props', () => {
     createSnapshotTest(<Section>Test Children</Section>);
   });
 
-  it('should render properly with all props assigned', () => {
+  it('should render with all props assigned', () => {
     createSnapshotTest(
       <Section
         className="testing-123"
@@ -25,38 +25,10 @@ describe('Section', () => {
     );
   });
 
-  it('should render properly with the most common use case', () => {
+  it('should render common use case', () => {
     createSnapshotTest(
       <Section theme="white" title="Test 2">
         Test Children 3
-      </Section>,
-    );
-  });
-
-  it('should render properly with a common use case 1', () => {
-    createSnapshotTest(
-      <Section theme="mist" title="Test 3">
-        Test Children 4
-      </Section>,
-    );
-  });
-
-  it('should render properly with a common use case 2', () => {
-    createSnapshotTest(
-      <Section hasHeadingLines={false} theme="slate" title="Test 4">
-        Test Children 5
-      </Section>,
-    );
-  });
-
-  it('should render properly with a common use case 3', () => {
-    createSnapshotTest(<Section contentClassName="TestClassName">Test Children 5</Section>);
-  });
-
-  it('should render properly with a default theme', () => {
-    createSnapshotTest(
-      <Section hasHeadingLines={false} theme="default" title="Test 6">
-        Test Children 6
       </Section>,
     );
   });

--- a/components/_common_/Section/__tests__/Section.test.js
+++ b/components/_common_/Section/__tests__/Section.test.js
@@ -5,11 +5,11 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import Section from '../Section';
 
 describe('Section', () => {
-  test('should render with just required props passed', () => {
+  it('should render with just required props passed', () => {
     createSnapshotTest(<Section>Test Children</Section>);
   });
 
-  test('should render properly with all props assigned', () => {
+  it('should render properly with all props assigned', () => {
     createSnapshotTest(
       <Section
         className="testing-123"
@@ -25,7 +25,7 @@ describe('Section', () => {
     );
   });
 
-  test('should render properly with the most common use case', () => {
+  it('should render properly with the most common use case', () => {
     createSnapshotTest(
       <Section theme="white" title="Test 2">
         Test Children 3
@@ -33,7 +33,7 @@ describe('Section', () => {
     );
   });
 
-  test('should render properly with a common use case 1', () => {
+  it('should render properly with a common use case 1', () => {
     createSnapshotTest(
       <Section theme="mist" title="Test 3">
         Test Children 4
@@ -41,7 +41,7 @@ describe('Section', () => {
     );
   });
 
-  test('should render properly with a common use case 2', () => {
+  it('should render properly with a common use case 2', () => {
     createSnapshotTest(
       <Section hasHeadingLines={false} theme="slate" title="Test 4">
         Test Children 5
@@ -49,11 +49,11 @@ describe('Section', () => {
     );
   });
 
-  test('should render properly with a common use case 3', () => {
+  it('should render properly with a common use case 3', () => {
     createSnapshotTest(<Section contentClassName="TestClassName">Test Children 5</Section>);
   });
 
-  test('should render properly with a default theme', () => {
+  it('should render properly with a default theme', () => {
     createSnapshotTest(
       <Section hasHeadingLines={false} theme="default" title="Test 6">
         Test Children 6

--- a/components/_common_/Section/__tests__/__snapshots__/Section.test.js.snap
+++ b/components/_common_/Section/__tests__/__snapshots__/Section.test.js.snap
@@ -1,77 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Section should render properly with a common use case 1 1`] = `
+exports[`Section should render common use case 1`] = `
 <section
-  className="Section mist"
+  className="Section white"
   style={Object {}}
 >
   <h2
     className="Heading slate headingLines"
     id=""
   >
-    Test 3
+    Test 2
   </h2>
   <div
     className="content "
   >
-    Test Children 4
+    Test Children 3
   </div>
 </section>
 `;
 
-exports[`Section should render properly with a common use case 2 1`] = `
-<section
-  className="Section slate"
-  style={Object {}}
->
-  <h2
-    className="Heading white"
-    id=""
-  >
-    Test 4
-  </h2>
-  <div
-    className="content "
-  >
-    Test Children 5
-  </div>
-</section>
-`;
-
-exports[`Section should render properly with a common use case 3 1`] = `
-<section
-  className="Section gray"
-  style={Object {}}
->
-  
-  <div
-    className="content TestClassName"
-  >
-    Test Children 5
-  </div>
-</section>
-`;
-
-exports[`Section should render properly with a default theme 1`] = `
-<section
-  className="Section default"
-  style={Object {}}
->
-  <h2
-    className="Heading gray"
-    id=""
-  >
-    Test 6
-  </h2>
-  <div
-    className="content "
-  >
-    Test Children 6
-  </div>
-</section>
-`;
-
-exports[`Section should render properly with all props assigned 1`] = `
+exports[`Section should render with all props assigned 1`] = `
 <section
   className="testing-123 Section grayLight"
   style={
@@ -94,26 +42,7 @@ exports[`Section should render properly with all props assigned 1`] = `
 </section>
 `;
 
-exports[`Section should render properly with the most common use case 1`] = `
-<section
-  className="Section white"
-  style={Object {}}
->
-  <h2
-    className="Heading slate headingLines"
-    id=""
-  >
-    Test 2
-  </h2>
-  <div
-    className="content "
-  >
-    Test Children 3
-  </div>
-</section>
-`;
-
-exports[`Section should render with just required props passed 1`] = `
+exports[`Section should render with required props 1`] = `
 <section
   className="Section gray"
   style={Object {}}

--- a/components/_common_/YouTubeVideo/__tests__/YouTubeVideo.test.js
+++ b/components/_common_/YouTubeVideo/__tests__/YouTubeVideo.test.js
@@ -5,11 +5,11 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import YouTubeVideo from '../YouTubeVideo';
 
 describe('YouTubeVideo', () => {
-  test('it should render properly with required props assigned', () => {
+  it('it should render properly with required props assigned', () => {
     createShallowSnapshotTest(<YouTubeVideo videoId="12345">test 1</YouTubeVideo>);
   });
 
-  test('it should render properly with some props assigned', () => {
+  it('it should render properly with some props assigned', () => {
     createShallowSnapshotTest(
       <YouTubeVideo className="YouTube-video" videoId="12395">
         test 2
@@ -17,7 +17,7 @@ describe('YouTubeVideo', () => {
     );
   });
 
-  test('it should render properly with all props assigned', () => {
+  it('it should render properly with all props assigned', () => {
     createShallowSnapshotTest(
       <YouTubeVideo className="YouTube-video" height="450px" width="875px" videoId="12395">
         test 3
@@ -25,7 +25,7 @@ describe('YouTubeVideo', () => {
     );
   });
 
-  test('should call onReady function', () => {
+  it('should call onReady function', () => {
     const mockFunc = jest.fn();
     const event = { target: { pauseVideo: mockFunc } };
 

--- a/components/_common_/YouTubeVideo/__tests__/YouTubeVideo.test.js
+++ b/components/_common_/YouTubeVideo/__tests__/YouTubeVideo.test.js
@@ -5,19 +5,11 @@ import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
 import YouTubeVideo from '../YouTubeVideo';
 
 describe('YouTubeVideo', () => {
-  it('it should render properly with required props assigned', () => {
+  it('should render with required props', () => {
     createShallowSnapshotTest(<YouTubeVideo videoId="12345">test 1</YouTubeVideo>);
   });
 
-  it('it should render properly with some props assigned', () => {
-    createShallowSnapshotTest(
-      <YouTubeVideo className="YouTube-video" videoId="12395">
-        test 2
-      </YouTubeVideo>,
-    );
-  });
-
-  it('it should render properly with all props assigned', () => {
+  it('should render with all props assigned', () => {
     createShallowSnapshotTest(
       <YouTubeVideo className="YouTube-video" height="450px" width="875px" videoId="12395">
         test 3
@@ -25,7 +17,7 @@ describe('YouTubeVideo', () => {
     );
   });
 
-  it('should call onReady function', () => {
+  it('should call onReady function on mount', () => {
     const mockFunc = jest.fn();
     const event = { target: { pauseVideo: mockFunc } };
 

--- a/components/_common_/YouTubeVideo/__tests__/__snapshots__/YouTubeVideo.test.js.snap
+++ b/components/_common_/YouTubeVideo/__tests__/__snapshots__/YouTubeVideo.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`YouTubeVideo it should render properly with all props assigned 1`] = `
+exports[`YouTubeVideo should render with all props assigned 1`] = `
 <YouTube
   className="YouTube-video YouTubeVideo"
   containerClassName=""
@@ -23,7 +23,7 @@ exports[`YouTubeVideo it should render properly with all props assigned 1`] = `
 />
 `;
 
-exports[`YouTubeVideo it should render properly with required props assigned 1`] = `
+exports[`YouTubeVideo should render with required props 1`] = `
 <YouTube
   className="YouTubeVideo"
   containerClassName=""
@@ -43,28 +43,5 @@ exports[`YouTubeVideo it should render properly with required props assigned 1`]
     }
   }
   videoId="12345"
-/>
-`;
-
-exports[`YouTubeVideo it should render properly with some props assigned 1`] = `
-<YouTube
-  className="YouTube-video YouTubeVideo"
-  containerClassName=""
-  id={null}
-  onEnd={[Function]}
-  onError={[Function]}
-  onPause={[Function]}
-  onPlay={[Function]}
-  onPlaybackQualityChange={[Function]}
-  onPlaybackRateChange={[Function]}
-  onReady={[Function]}
-  onStateChange={[Function]}
-  opts={
-    Object {
-      "height": "390",
-      "width": "640",
-    }
-  }
-  videoId="12395"
 />
 `;

--- a/jest.config.js
+++ b/jest.config.js
@@ -133,7 +133,8 @@ module.exports = {
   // runner: "jest-runner",
 
   // The paths to modules that run some code to configure or set up the testing environment before each test
-  // setupFiles: [],
+  // TODO: Enable and resolve related issues
+  // setupFiles: ['jest-prop-type-error'],
 
   // The path to a module that runs some code to configure or set up the testing framework before each test
   setupTestFrameworkScriptFile: '<rootDir>/jest.setup.js',

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-prettier": "^3.1.0",
     "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-jest": "^21.24.1",
     "eslint-plugin-jsx-a11y": "^6.1.1",
     "eslint-plugin-react": "^7.11.1",
     "husky": "0.14.3",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "jest": "^23.6.0",
     "jest-enzyme": "6.1.2",
     "jest-mock-axios": "^2.1.11",
+    "jest-prop-type-error": "^1.1.0",
     "lint-staged": "^7.3.0",
     "prettier": "^1.14.3",
     "react-addons-test-utils": "^15.6.2",

--- a/scripts/createComponent/builders.js
+++ b/scripts/createComponent/builders.js
@@ -63,11 +63,11 @@ import createSnapshotTest from 'test-utils/createSnapshotTest';
 import ${componentName} from '../${componentName}';
 
 describe('${componentName}', () => {
-  it('should render with just required props passed', () => {
+  it('should render with required props', () => {
     createSnapshotTest(<${componentName}>Test</${componentName}>);
   });
 
-  it('should render properly with all props assigned', () => {
+  it('should render with all props assigned', () => {
     createSnapshotTest(
       <${componentName} className="test-class">
         Test

--- a/yarn.lock
+++ b/yarn.lock
@@ -7129,6 +7129,11 @@ jest-mock@^23.2.0:
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.2.0.tgz#ad1c60f29e8719d47c26e1138098b6d18b261134"
   integrity sha1-rRxg8p6HGdR8JuETgJi20YsmETQ=
 
+jest-prop-type-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jest-prop-type-error/-/jest-prop-type-error-1.1.0.tgz#7949a73cef6b9769ed9811139933b4139d2d8ad9"
+  integrity sha512-i/4hdbKSp6cFJc2z3Blu2WEOGjxbQ76pShhtDFIqUfdC8ruMGT57EOsBtBq69FVg915MUMwENNc185ejs7mmtg==
+
 jest-regex-util@^23.3.0:
   version "23.3.0"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-23.3.0.tgz#5f86729547c2785c4002ceaa8f849fe8ca471bc5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4802,6 +4802,11 @@ eslint-plugin-import@^2.14.0:
     read-pkg-up "^2.0.0"
     resolve "^1.6.0"
 
+eslint-plugin-jest@^21.24.1:
+  version "21.24.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.24.1.tgz#aaf3c34e816f07add83d1e9c20696fdc31fac8dc"
+  integrity sha512-+lJ6nvwJtDRQtTumCs/9gMuteiopArpHJbRbWqPaScCzlhTu1pEilWTUlTgDEtY7GOx7FdOMD3BO/mdxFb4yDg==
+
 eslint-plugin-jsx-a11y@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.1.1.tgz#7bf56dbe7d47d811d14dbb3ddff644aa656ce8e1"


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
- Add `eslint-plugin-jest` + `jest-prop-type-error` to devDeps ☑️ 
- Define `eslint-plugin-jest` rules and resolve onset lint issues 📐 
- Remove unnecessary utility function test cases  🙅‍♂️ 
- Refactor `<Button>` and utility function tests 🚧 
- *Convert many test names to be uniform 👮‍♀️ 
- Remove unnecessary props from many tests 🚯 
- Update snapshots 😜 

---

* -->
"All" props is a moving target as code is changed. This naming implicitly converts a snapshot test to supreme brittleness.
- Settle on two types of snapshot test names:
 1. `should render with required props`
 2. `should render with many props assigned`
> The only issue with the above definition is that 1 and 2 may the same. In that case, it is preferred to only test #1.