### PR TITLE
Adding greenkeeper to ignore husky dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,5 +108,10 @@
     "stylelint": "^9.6.0",
     "stylelint-config-standard": "^18.2.0",
     "webpack-bundle-analyzer": "^3.0.2"
+  },
+  "greenkeeper": {
+    "ignore": [
+        "husky"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "greenkeeper": {
     "ignore": [
-        "husky"
+      "husky"
     ]
   }
 }


### PR DESCRIPTION
# Description of changes
It adds a greenkeeper rule to ignore husky dependency.

# Issue Resolved
Fixes #221 

## Screenshots/GIFs

