### PR TITLE
[Feature] Screen Reader-only component

### DIFF
--- a/common/config/svgo.js
+++ b/common/config/svgo.js
@@ -26,6 +26,11 @@ const svgoConfig = {
     { removeUselessStrokeAndFill: true },
     { removeXMLProcInst: true },
     { sortAttrs: true },
+    {
+      addAttributesToSVGElement: {
+        attribute: 'aria-hidden="true"',
+      },
+    },
   ],
   floatPrecision: 3,
 };

--- a/components/AdBanner/__stories__/__snapshots__/AdBanner.stories.storyshot
+++ b/components/AdBanner/__stories__/__snapshots__/AdBanner.stories.storyshot
@@ -8,7 +8,7 @@ exports[`Storyshots AdBanner default 1`] = `
   target="_blank"
 >
   <span
-    className="screenReaderOnly"
+    className="ScreenReaderOnly"
   >
     Opens in new window
   </span>

--- a/components/Cards/SchoolCard/__stories__/__snapshots__/SchoolCard.stories.storyshot
+++ b/components/Cards/SchoolCard/__stories__/__snapshots__/SchoolCard.stories.storyshot
@@ -8,7 +8,7 @@ exports[`Storyshots Cards/SchoolCard default 1`] = `
   target="_blank"
 >
   <span
-    className="screenReaderOnly"
+    className="ScreenReaderOnly"
   >
     Opens in new window
   </span>

--- a/components/Cards/SchoolCard/__tests__/__snapshots__/SchoolCard.test.js.snap
+++ b/components/Cards/SchoolCard/__tests__/__snapshots__/SchoolCard.test.js.snap
@@ -8,7 +8,7 @@ exports[`SchoolCard should render with many props assigned 1`] = `
   target="_blank"
 >
   <span
-    className="screenReaderOnly"
+    className="ScreenReaderOnly"
   >
     Opens in new window
   </span>
@@ -73,7 +73,7 @@ exports[`SchoolCard should render with required props 1`] = `
   target="_blank"
 >
   <span
-    className="screenReaderOnly"
+    className="ScreenReaderOnly"
   >
     Opens in new window
   </span>

--- a/components/Cards/TeamMemberCard/__stories__/__snapshots__/TeamMemberCard.stories.storyshot
+++ b/components/Cards/TeamMemberCard/__stories__/__snapshots__/TeamMemberCard.stories.storyshot
@@ -33,7 +33,7 @@ exports[`Storyshots Cards/TeamMemberCard default 1`] = `
         target="_blank"
       >
         <span
-          className="screenReaderOnly"
+          className="ScreenReaderOnly"
         >
           Opens in new window
         </span>
@@ -56,7 +56,7 @@ exports[`Storyshots Cards/TeamMemberCard default 1`] = `
         target="_blank"
       >
         <span
-          className="screenReaderOnly"
+          className="ScreenReaderOnly"
         >
           Opens in new window
         </span>

--- a/components/Cards/TeamMemberCard/__tests__/__snapshots__/TeamMemberCard.test.js.snap
+++ b/components/Cards/TeamMemberCard/__tests__/__snapshots__/TeamMemberCard.test.js.snap
@@ -33,7 +33,7 @@ exports[`TeamMemberCard should render with many props assigned 1`] = `
         target="_blank"
       >
         <span
-          className="screenReaderOnly"
+          className="ScreenReaderOnly"
         >
           Opens in new window
         </span>
@@ -56,7 +56,7 @@ exports[`TeamMemberCard should render with many props assigned 1`] = `
         target="_blank"
       >
         <span
-          className="screenReaderOnly"
+          className="ScreenReaderOnly"
         >
           Opens in new window
         </span>

--- a/components/FeaturedJobItem/__stories__/__snapshots__/FeaturedJobItem.stories.storyshot
+++ b/components/FeaturedJobItem/__stories__/__snapshots__/FeaturedJobItem.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots FeaturedJobItem default 1`] = `
       target="_blank"
     >
       <span
-        className="screenReaderOnly"
+        className="ScreenReaderOnly"
       >
         Opens in new window
       </span>

--- a/components/FeaturedJobItem/__tests__/__snapshots__/FeaturedJobItem.test.js.snap
+++ b/components/FeaturedJobItem/__tests__/__snapshots__/FeaturedJobItem.test.js.snap
@@ -11,7 +11,7 @@ exports[`FeaturedJobItem should render with many props assigned 1`] = `
       target="_blank"
     >
       <span
-        className="screenReaderOnly"
+        className="ScreenReaderOnly"
       >
         Opens in new window
       </span>
@@ -93,7 +93,7 @@ exports[`FeaturedJobItem should render with required props 1`] = `
       target="_blank"
     >
       <span
-        className="screenReaderOnly"
+        className="ScreenReaderOnly"
       >
         Opens in new window
       </span>

--- a/components/ReusableSections/__stories__/__snapshots__/ReusableSections.stories.storyshot
+++ b/components/ReusableSections/__stories__/__snapshots__/ReusableSections.stories.storyshot
@@ -37,7 +37,7 @@ exports[`Storyshots ReusableSections DonateSection 1`] = `
         target="_blank"
       >
         <span
-          className="screenReaderOnly"
+          className="ScreenReaderOnly"
         >
           Opens in new window
         </span>

--- a/components/SocialMedia/SocialMediaItem/__tests__/__snapshots__/SocialMediaItem.test.js.snap
+++ b/components/SocialMedia/SocialMediaItem/__tests__/__snapshots__/SocialMediaItem.test.js.snap
@@ -10,7 +10,7 @@ exports[`SocialMediaItem should render with required props 1`] = `
     target="_blank"
   >
     <span
-      className="screenReaderOnly"
+      className="ScreenReaderOnly"
     >
       Opens in new window
     </span>

--- a/components/_common_/OutboundLink/OutboundLink.css
+++ b/components/_common_/OutboundLink/OutboundLink.css
@@ -1,14 +1,3 @@
-.screenReaderOnly {
-  border: 0;
-  clip: rect(0, 0, 0, 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-}
-
 .externalLinkIcon {
   fill: currentColor;
   left: 4px;

--- a/components/_common_/OutboundLink/OutboundLink.js
+++ b/components/_common_/OutboundLink/OutboundLink.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import ReactGA from 'react-ga';
 import { withRouter } from 'next/router';
 import ExternalLinkIcon from 'static/images/icons/FontAwesome/external-link-square-alt-solid.svg';
+import ScreenReaderOnly from 'components/_common_/ScreenReaderOnly/ScreenReaderOnly';
 import styles from './OutboundLink.css';
 
 OutboundLink.propTypes = {
@@ -22,7 +23,7 @@ OutboundLink.defaultProps = {
 function OutboundLink({ analyticsEventLabel, children, className, hasIcon, href, router }) {
   const linkContent = (
     <React.Fragment>
-      <span className={styles.screenReaderOnly}>Opens in new window</span>
+      <ScreenReaderOnly>Opens in new window</ScreenReaderOnly>
       {children}
       {hasIcon && <ExternalLinkIcon className={styles.externalLinkIcon} />}
     </React.Fragment>

--- a/components/_common_/OutboundLink/__stories__/__snapshots__/OutboundLink.stories.storyshot
+++ b/components/_common_/OutboundLink/__stories__/__snapshots__/OutboundLink.stories.storyshot
@@ -7,7 +7,7 @@ exports[`Storyshots Common/OutboundLink default 1`] = `
   target="_blank"
 >
   <span
-    className="screenReaderOnly"
+    className="ScreenReaderOnly"
   >
     Opens in new window
   </span>

--- a/components/_common_/OutboundLink/__tests__/__snapshots__/OutboundLink.test.js.snap
+++ b/components/_common_/OutboundLink/__tests__/__snapshots__/OutboundLink.test.js.snap
@@ -8,7 +8,7 @@ exports[`OutboundLink should render with many props assigned 1`] = `
   target="_blank"
 >
   <span
-    className="screenReaderOnly"
+    className="ScreenReaderOnly"
   >
     Opens in new window
   </span>
@@ -23,7 +23,7 @@ exports[`OutboundLink should render with required props 1`] = `
   target="_blank"
 >
   <span
-    className="screenReaderOnly"
+    className="ScreenReaderOnly"
   >
     Opens in new window
   </span>

--- a/components/_common_/ScreenReaderOnly/ScreenReaderOnly.css
+++ b/components/_common_/ScreenReaderOnly/ScreenReaderOnly.css
@@ -1,0 +1,10 @@
+.ScreenReaderOnly {
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}

--- a/components/_common_/ScreenReaderOnly/ScreenReaderOnly.js
+++ b/components/_common_/ScreenReaderOnly/ScreenReaderOnly.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './ScreenReaderOnly.css';
+
+ScreenReaderOnly.propTypes = {
+  children: PropTypes.string.isRequired,
+};
+
+export default function ScreenReaderOnly({ children }) {
+  return <span className={styles.ScreenReaderOnly}>{children}</span>;
+}

--- a/components/_common_/ScreenReaderOnly/__stories__/ScreenReaderOnly.stories.js
+++ b/components/_common_/ScreenReaderOnly/__stories__/ScreenReaderOnly.stories.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+import { withKnobs, text } from '@storybook/addon-knobs';
+
+import ScreenReaderOnly from '../ScreenReaderOnly';
+
+storiesOf('Common/ScreenReaderOnly', module)
+  .addDecorator(withKnobs)
+  .add(
+    'default',
+    withInfo()(() => (
+      <ScreenReaderOnly>
+        {text('children', 'This content is never displayed, but it is rendered')}
+      </ScreenReaderOnly>
+    )),
+  );

--- a/components/_common_/ScreenReaderOnly/__stories__/__snapshots__/ScreenReaderOnly.stories.storyshot
+++ b/components/_common_/ScreenReaderOnly/__stories__/__snapshots__/ScreenReaderOnly.stories.storyshot
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Common/ScreenReaderOnly default 1`] = `
+<span
+  className="ScreenReaderOnly"
+>
+  This content is never displayed, but it is rendered
+</span>
+`;

--- a/components/_common_/ScreenReaderOnly/__tests__/ScreenReaderOnly.test.js
+++ b/components/_common_/ScreenReaderOnly/__tests__/ScreenReaderOnly.test.js
@@ -1,0 +1,11 @@
+/* eslint-env jest */
+import React from 'react';
+import createSnapshotTest from 'test-utils/createSnapshotTest';
+
+import ScreenReaderOnly from '../ScreenReaderOnly';
+
+describe('ScreenReaderOnly', () => {
+  it('should render with required props', () => {
+    createSnapshotTest(<ScreenReaderOnly>Test</ScreenReaderOnly>);
+  });
+});

--- a/components/_common_/ScreenReaderOnly/__tests__/__snapshots__/ScreenReaderOnly.test.js.snap
+++ b/components/_common_/ScreenReaderOnly/__tests__/__snapshots__/ScreenReaderOnly.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ScreenReaderOnly should render with required props 1`] = `
+<span
+  className="ScreenReaderOnly"
+>
+  Test
+</span>
+`;


### PR DESCRIPTION
- Used in conjunction with decorative content to define meaning when needed
- Also mapped `aria-hidden="true"` to all SVGs via SVGO