### PR TITLE
[Feature] - Generate breakpoints dynamically

### DIFF
--- a/.storybook/backgrounds.js
+++ b/.storybook/backgrounds.js
@@ -2,7 +2,6 @@ import addonBackgrounds from '@storybook/addon-backgrounds';
 import { brandColorsObject } from 'common/styles/styleExports';
 import { capitalizeFirstLetter } from 'common/utils/string-utils';
 
-// For Backgrounds Addon
 const backgroundsPaletteArray = Object.keys(brandColorsObject).map(name => ({
   name: capitalizeFirstLetter(name),
   value: brandColorsObject[name],

--- a/.storybook/backgrounds.js
+++ b/.storybook/backgrounds.js
@@ -1,5 +1,13 @@
 import addonBackgrounds from '@storybook/addon-backgrounds';
-import backgroundsPaletteArray from 'common/styles/styleExports';
+import { brandColorsObject } from 'common/styles/styleExports';
+import { capitalizeFirstLetter } from 'common/utils/string-utils';
+
+// For Backgrounds Addon
+const backgroundsPaletteArray = Object.keys(brandColorsObject).map(name => ({
+  name: capitalizeFirstLetter(name),
+  value: brandColorsObject[name],
+  default: name === 'mist',
+}));
 
 const brandingBackgrounds = addonBackgrounds(backgroundsPaletteArray);
 

--- a/common/styles/breakpoints.js
+++ b/common/styles/breakpoints.js
@@ -1,0 +1,6 @@
+import { breakpointsObject } from 'common/styles/styleExports';
+import { getBreakpoints } from 'common/utils/style-utils';
+
+const breakpoints = getBreakpoints(Object.values(breakpointsObject));
+
+export default breakpoints;

--- a/common/styles/styleExports.js
+++ b/common/styles/styleExports.js
@@ -1,15 +1,23 @@
-import { capitalizeFirstLetter } from 'common/utils/string-utils';
+import { hasPixelSuffix, isHexColor } from 'common/utils/style-utils';
 import * as themeMap from './themeMap';
 
-const colorHexCodes = Object.entries(themeMap);
+export const breakpointsObject = Object.entries(themeMap).reduce((obj, [key, value]) => {
+  if (hasPixelSuffix(value)) {
+    obj[key] = value; // eslint-disable-line no-param-reassign
+  }
 
-// For Backgrounds Addon
-const backgroundsPaletteArray = colorHexCodes
-  .filter(([name]) => !(name.includes('Light') || name.includes('Dark')))
-  .map(([name, hexCode]) => ({
-    name: capitalizeFirstLetter(name),
-    value: hexCode,
-    default: name === 'mist',
-  }));
+  return obj;
+}, {});
 
-export default backgroundsPaletteArray;
+export const brandColorsObject = Object.entries(themeMap).reduce((obj, [key, value]) => {
+  if (isHexColor(value)) {
+    // We don't want to include modifier colors like `primaryLight`
+    const isBrandColor = !(key.includes('Light') || key.includes('Dark'));
+
+    if (isBrandColor) {
+      obj[key] = value; // eslint-disable-line no-param-reassign
+    }
+  }
+
+  return obj;
+}, {});

--- a/common/styles/themeMap.js
+++ b/common/styles/themeMap.js
@@ -12,3 +12,7 @@ export const gray = "#9baab5";
 export const grayLight = "#d0d5da";
 export const grayDark = "#75848f";
 export const navy = "#252e3e";
+export const smallViewportWidth = "576px";
+export const mediumViewportWidth = "768px";
+export const largeViewportWidth = "992px";
+export const extraLargeViewportWidth = "1200px";

--- a/common/styles/variables.css
+++ b/common/styles/variables.css
@@ -1,5 +1,6 @@
-/* IMPORTANT: Only change colors in this file if branding changes! */
+/* IMPORTANT: Please run `yarn storybook` when file changes to update `./themeMap.js` */
 :root {
+  /* Colors */
   --primary: #249cbc;
   --primaryLight: #4ac2e2;
   --primaryDark: #007696;
@@ -14,4 +15,10 @@
   --grayLight: #d0d5da;
   --grayDark: #75848f;
   --navy: #252e3e;
+
+  /* Viewports (for media queries) */
+  --smallViewportWidth: 576px;
+  --mediumViewportWidth: 768px;
+  --largeViewportWidth: 992px;
+  --extraLargeViewportWidth: 1200px;
 }

--- a/common/utils/__tests__/style-utils.test.js
+++ b/common/utils/__tests__/style-utils.test.js
@@ -4,6 +4,7 @@ import {
   hasPixelSuffix,
   isHexColor,
   getSortedBreakpointValues,
+  getBreakpoints,
 } from '../style-utils';
 
 describe('Style Utilities', () => {
@@ -71,6 +72,32 @@ describe('Style Utilities', () => {
 
     it('should return breakpoint-related values in order from least to greatest', () => {
       expect(getSortedBreakpointValues(testValues)).toStrictEqual([...sortedBreakpointValues]);
+    });
+  });
+
+  describe('getBreakpoints', () => {
+    const testValues = ['768px', '1000px', '900px', '500px'];
+
+    const errorMessage = `We require a small, medium, large, and extra-large breakpoint. Ensure
+      "common/styles/variables.css" has exactly 4 breakpoint values.`;
+
+    it('should throw an error when passed an array with fewer than 4 items', () => {
+      expect(() => getBreakpoints([testValues[0], testValues[1], testValues[2]])).toThrow(
+        errorMessage,
+      );
+    });
+
+    it('should throw an error when passed an array with more than 4 items', () => {
+      expect(() => getBreakpoints([...testValues, '1200px'])).toThrow(errorMessage);
+    });
+
+    it('should return a breakpoint object when passed an array of 4 pixel-suffixed values', () => {
+      expect(getBreakpoints(testValues)).toStrictEqual({
+        sm: 500,
+        md: 768,
+        lg: 900,
+        xl: 1000,
+      });
     });
   });
 });

--- a/common/utils/__tests__/style-utils.test.js
+++ b/common/utils/__tests__/style-utils.test.js
@@ -1,0 +1,76 @@
+/* eslint-env jest */
+import {
+  getNumberFromPixelValue,
+  hasPixelSuffix,
+  isHexColor,
+  getSortedBreakpointValues,
+} from '../style-utils';
+
+describe('Style Utilities', () => {
+  describe('getNumberFromPixelValue', () => {
+    it('should return 50 when passed "50px"', () => {
+      expect(getNumberFromPixelValue('50px')).toStrictEqual(50);
+    });
+
+    it('should return 1000 when passed "1000px"', () => {
+      expect(getNumberFromPixelValue('1000px')).toStrictEqual(1000);
+    });
+
+    it('should error when passing a string without a pixel unit suffix', () => {
+      expect(() => getNumberFromPixelValue('700')).toThrow('700 is not a pixel value!');
+    });
+  });
+
+  describe('hasPixelSuffix', () => {
+    it('should return true if px is at the end of the string', () => {
+      expect(hasPixelSuffix('700px')).toStrictEqual(true);
+    });
+
+    it('should return false the string is just px', () => {
+      expect(hasPixelSuffix('px')).toStrictEqual(false);
+    });
+
+    it('should return false if not related to pixel value', () => {
+      expect(hasPixelSuffix('#663399')).toStrictEqual(false);
+    });
+  });
+
+  describe('isHexColor', () => {
+    it('should return true if # is at the start of passed string of 4 characters', () => {
+      expect(isHexColor('#3ab')).toStrictEqual(true);
+    });
+
+    it('should return true if # is at the start of passed string of 7 all-caps characters', () => {
+      expect(isHexColor('#FFFFFF')).toStrictEqual(true);
+    });
+
+    it('should return false if passed string is just #', () => {
+      expect(isHexColor('#')).toStrictEqual(false);
+    });
+
+    it('should return false if passed string starts with #, but is 5 characters long', () => {
+      expect(isHexColor('#2345')).toStrictEqual(false);
+    });
+
+    it('should return false if passed string starts with #, but is 10 characters long', () => {
+      expect(isHexColor('#123456789')).toStrictEqual(false);
+    });
+
+    it('should throw an error if not passed a string', () => {
+      expect(() => isHexColor(3725)).toThrow('Must pass a string to this method.');
+    });
+  });
+
+  describe('getSortedBreakpointValues', () => {
+    const testValues = ['768px', '1000px', '900px'];
+    const sortedBreakpointValues = [768, 900, 1000];
+
+    it('should return an array', () => {
+      expect(Array.isArray(getSortedBreakpointValues(testValues))).toStrictEqual(true);
+    });
+
+    it('should return breakpoint-related values in order from least to greatest', () => {
+      expect(getSortedBreakpointValues(testValues)).toStrictEqual([...sortedBreakpointValues]);
+    });
+  });
+});

--- a/common/utils/string-utils.js
+++ b/common/utils/string-utils.js
@@ -4,7 +4,7 @@
  * */
 
 /**
- * Capitalize the first letter in a string
+ * @description Capitalize the first letter in a string
  *
  * @export
  * @param {string} someString

--- a/common/utils/style-utils.js
+++ b/common/utils/style-utils.js
@@ -27,6 +27,32 @@ export function hasPixelSuffix(someString) {
 }
 
 /**
+ * @description Check to see if a string is a valid hex color
+ *
+ * @exports
+ * @param {string} someString
+ * @throws Will throw an error if method is not passed a string
+ * @returns {boolean}
+ */
+export function isHexColor(someString) {
+  if (typeof someString !== 'string') {
+    throw new Error('Must pass a string to this method.');
+  }
+
+  // #FFF (smallest possible hex color pattern)
+  // #FFFFFF (largest possible hex color pattern)
+  const stringLength = someString.length;
+  if (stringLength !== 4 && stringLength !== 7) {
+    return false;
+  }
+
+  // Edge Cases: If you pass characters unrelated to a hex letter like 'g' or '+'
+  // and it begins with a hashtag, you'll get a false-positive
+
+  return someString.startsWith('#');
+}
+
+/**
  * @description Get a sorted array of every breakpoint value converted to a number
  *
  * @exports
@@ -73,30 +99,4 @@ export function getBreakpoints(arrayOfBreakpointValues) {
     lg: sortedBreakpointValues[2],
     xl: sortedBreakpointValues[3],
   };
-}
-
-/**
- * @description Check to see if a string is a valid hex color
- *
- * @exports
- * @param {string} someString
- * @throws Will throw an error if method is not passed a string
- * @returns {boolean}
- */
-export function isHexColor(someString) {
-  if (typeof someString !== 'string') {
-    throw new Error('Must pass a string to this method.');
-  }
-
-  // #FFF (smallest possible hex color pattern)
-  // #FFFFFF (largest possible hex color pattern)
-  const stringLength = someString.length;
-  if (stringLength !== 4 && stringLength !== 7) {
-    return false;
-  }
-
-  // Edge Cases: If you pass characters unrelated to a hex letter like 'g' or '+'
-  // and it begins with a hashtag, you'll get a false-positive
-
-  return someString.startsWith('#');
 }

--- a/common/utils/style-utils.js
+++ b/common/utils/style-utils.js
@@ -84,14 +84,14 @@ export function getSortedBreakpointValues(arrayOfBreakpointValues) {
  * @returns {Breakpoints}
  */
 export function getBreakpoints(arrayOfBreakpointValues) {
-  const sortedBreakpointValues = getSortedBreakpointValues(arrayOfBreakpointValues);
-
-  if (sortedBreakpointValues.length !== 4) {
+  if (arrayOfBreakpointValues.length !== 4) {
     throw new Error(`
       We require a small, medium, large, and extra-large breakpoint. Ensure
       "common/styles/variables.css" has exactly 4 breakpoint values.
     `);
   }
+
+  const sortedBreakpointValues = getSortedBreakpointValues(arrayOfBreakpointValues);
 
   return {
     sm: sortedBreakpointValues[0],

--- a/common/utils/style-utils.js
+++ b/common/utils/style-utils.js
@@ -1,0 +1,102 @@
+/**
+ * @description Return the number from a pixel-valued string
+ *
+ * @exports
+ * @param {string} pxValue (ex: "768px")
+ * @returns {number}
+ */
+export function getNumberFromPixelValue(pxValue) {
+  if (!hasPixelSuffix(pxValue)) {
+    throw new Error(`${pxValue} is not a pixel value!`);
+  }
+
+  const [value] = pxValue.split('px');
+  const number = parseInt(value, 10);
+  return number;
+}
+
+/**
+ * @description Check if a string has px at the end of it.
+ *
+ * @exports
+ * @param {string} someString
+ * @returns {boolean}
+ */
+export function hasPixelSuffix(someString) {
+  return someString.slice(-2) === 'px' && someString.length > 2;
+}
+
+/**
+ * @description Get a sorted array of every breakpoint value converted to a number
+ *
+ * @exports
+ * @param {string[]} arrayOfBreakpointValues
+ * @returns {string[]}
+ */
+export function getSortedBreakpointValues(arrayOfBreakpointValues) {
+  return arrayOfBreakpointValues
+    .map(pixelValue => getNumberFromPixelValue(pixelValue))
+    .sort((a, b) => a - b);
+}
+
+/**
+ * An object representing the application's visual breakpoints.
+ * @typedef {{
+ * sm: number,
+ * md: number,
+ * lg: number,
+ * xl: number
+ * }} Breakpoints
+ */
+
+/**
+ * @description Take an array of every CSS variable value, return a Breakpoint object
+ *
+ * @exports
+ * @param {string[]} arrayOfBreakpointValues
+ * @throws Will throw an error if breakpoint-related values array is not exactly length 4
+ * @returns {Breakpoints}
+ */
+export function getBreakpoints(arrayOfBreakpointValues) {
+  const sortedBreakpointValues = getSortedBreakpointValues(arrayOfBreakpointValues);
+
+  if (sortedBreakpointValues.length !== 4) {
+    throw new Error(`
+      We require a small, medium, large, and extra-large breakpoint. Ensure
+      "common/styles/variables.css" has exactly 4 breakpoint values.
+    `);
+  }
+
+  return {
+    sm: sortedBreakpointValues[0],
+    md: sortedBreakpointValues[1],
+    lg: sortedBreakpointValues[2],
+    xl: sortedBreakpointValues[3],
+  };
+}
+
+/**
+ * @description Check to see if a string is a valid hex color
+ *
+ * @exports
+ * @param {string} someString
+ * @throws Will throw an error if method is not passed a string
+ * @returns {boolean}
+ */
+export function isHexColor(someString) {
+  if (typeof someString !== 'string') {
+    throw new Error('Must pass a string to this method.');
+  }
+
+  // #FFF (smallest possible hex color pattern)
+  // #FFFFFF (largest possible hex color pattern)
+  const stringLength = someString.length;
+  if (stringLength !== 4 && stringLength !== 7) {
+    return false;
+  }
+
+  // Edge Cases: If you pass characters unrelated to a hex letter like 'g' or '+'
+  // and it begins with a hashtag, you'll get a false-positive
+
+  return someString.startsWith('#');
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,6 +24,8 @@ module.exports = {
   collectCoverageFrom: [
     '<rootDir>/common/**/*.js',
     '<rootDir>/components/**/*.js',
+
+    // Don't collect coverage from import/export mappers
     '!<rootDir>/common/**/index.js',
     '!<rootDir>/components/**/index.js',
   ],

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "redux": "^4.0.1",
     "redux-devtools-extension": "^2.13.5",
     "redux-thunk": "^2.3.0",
+    "selector": "^1.0.0",
     "style-loader": "^0.23.1",
     "universal-cookie": "^3.0.4",
     "webpack": "^4.25.1"

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.11",
     "next": "^7.0.2",
+    "next-redux-wrapper": "^2.0.0",
     "path": "^0.12.7",
     "postcss-export-custom-variables": "^1.0.0",
     "postcss-import": "^12.0.1",
@@ -79,6 +80,9 @@
     "react-scroll-up-button": "^1.6.4",
     "react-svg-loader": "^2.1.0",
     "react-youtube": "^7.8.0",
+    "redux": "^4.0.1",
+    "redux-devtools-extension": "^2.13.5",
+    "redux-thunk": "^2.3.0",
     "style-loader": "^0.23.1",
     "universal-cookie": "^3.0.4",
     "webpack": "^4.25.1"
@@ -108,6 +112,7 @@
     "prettier": "^1.15.2",
     "react-addons-test-utils": "^15.6.2",
     "react-test-renderer": "^16.6.1",
+    "redux-mock-store": "^1.5.3",
     "stylelint": "^9.8.0",
     "stylelint-config-standard": "^18.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.11",
     "next": "^7.0.2",
-    "next-redux-wrapper": "^2.0.0",
     "path": "^0.12.7",
     "postcss-export-custom-variables": "^1.0.0",
     "postcss-import": "^12.0.1",
@@ -80,10 +79,6 @@
     "react-scroll-up-button": "^1.6.4",
     "react-svg-loader": "^2.1.0",
     "react-youtube": "^7.8.0",
-    "redux": "^4.0.1",
-    "redux-devtools-extension": "^2.13.5",
-    "redux-thunk": "^2.3.0",
-    "selector": "^1.0.0",
     "style-loader": "^0.23.1",
     "universal-cookie": "^3.0.4",
     "webpack": "^4.25.1"
@@ -113,7 +108,6 @@
     "prettier": "^1.15.2",
     "react-addons-test-utils": "^15.6.2",
     "react-test-renderer": "^16.6.1",
-    "redux-mock-store": "^1.5.3",
     "stylelint": "^9.8.0",
     "stylelint-config-standard": "^18.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10036,6 +10036,11 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
+selector@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/selector/-/selector-1.0.0.tgz#84b04fafc6b90bfa237a9d1b097062f163022fbd"
+  integrity sha512-Y0G7V2W8PuWyZv+w3OfTx+pu0BbWxBqEqkVCxI8q2APGYygChngpjWBiL9OzGOg9Y8JMH47sTTvLOHlaCCI5kw==
+
 semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7228,7 +7228,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
@@ -7688,11 +7688,6 @@ neo-async@^2.5.0:
 nested-object-assign@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/nested-object-assign/-/nested-object-assign-1.0.3.tgz#5aca69390d9affe5a612152b5f0843ae399ac597"
-
-next-redux-wrapper@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/next-redux-wrapper/-/next-redux-wrapper-2.0.0.tgz#74587381ff9c762cd85676d9739a51a3aeceed58"
-  integrity sha512-QcaEK7pUelShCk6Epajvp3MZrktt/0bVR0f2ssaZtQ270q80zLhKIKFkVZL8uwqXMnSJInZDSwcAhYhn8/Rpsw==
 
 next-tick@1:
   version "1.0.0"
@@ -9550,23 +9545,6 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^0.4.2"
 
-redux-devtools-extension@^2.13.5:
-  version "2.13.5"
-  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.5.tgz#3ff34f7227acfeef3964194f5f7fc2765e5c5a39"
-  integrity sha512-QQ9BRy77oURHMdGys9rfQcCQDzXZ1T4oW+eUyE5Cg7DNVau69HJzc4YNDMOmpi0Dzpi1zOQgQ2rUpgJta4Lfqg==
-
-redux-mock-store@^1.5.3:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.3.tgz#1f10528949b7ce8056c2532624f7cafa98576c6d"
-  integrity sha512-ryhkkb/4D4CUGpAV2ln1GOY/uh51aczjcRz9k2L2bPx/Xja3c5pSGJJPyR25GNVRXtKIExScdAgFdiXp68GmJA==
-  dependencies:
-    lodash.isplainobject "^4.0.6"
-
-redux-thunk@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
-  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
-
 redux@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
@@ -9575,14 +9553,6 @@ redux@^3.7.2:
     lodash-es "^4.2.1"
     loose-envify "^1.1.0"
     symbol-observable "^1.0.3"
-
-redux@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"
-  integrity sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==
-  dependencies:
-    loose-envify "^1.4.0"
-    symbol-observable "^1.2.0"
 
 reflect.ownkeys@^0.2.0:
   version "0.2.0"
@@ -10035,11 +10005,6 @@ schema-utils@^1.0.0:
     ajv "^6.1.0"
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
-
-selector@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/selector/-/selector-1.0.0.tgz#84b04fafc6b90bfa237a9d1b097062f163022fbd"
-  integrity sha512-Y0G7V2W8PuWyZv+w3OfTx+pu0BbWxBqEqkVCxI8q2APGYygChngpjWBiL9OzGOg9Y8JMH47sTTvLOHlaCCI5kw==
 
 semver-compare@^1.0.0:
   version "1.0.0"
@@ -10742,7 +10707,7 @@ svgo@^0.7.0, svgo@^0.7.2:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-symbol-observable@^1.0.3, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
+symbol-observable@^1.0.3, symbol-observable@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1537,10 +1537,6 @@ ansi-colors@^3.0.0:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.0.6.tgz#a0b9e00e8c1cc6685b1c3130dbeb9abed03ca6a4"
 
-ansi-escapes@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
-
 ansi-escapes@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
@@ -7001,20 +6997,7 @@ listr-silent-renderer@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
 
-listr-update-renderer@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz#344d980da2ca2e8b145ba305908f32ae3f4cc8a7"
-  dependencies:
-    chalk "^1.1.3"
-    cli-truncate "^0.2.1"
-    elegant-spinner "^1.0.1"
-    figures "^1.7.0"
-    indent-string "^3.0.0"
-    log-symbols "^1.0.2"
-    log-update "^1.0.2"
-    strip-ansi "^3.0.1"
-
-"listr-update-renderer@https://github.com/okonet/listr-update-renderer/tarball/upgrade-log-update":
+listr-update-renderer@^0.4.0, "listr-update-renderer@https://github.com/okonet/listr-update-renderer/tarball/upgrade-log-update":
   version "0.4.0"
   resolved "https://github.com/okonet/listr-update-renderer/tarball/upgrade-log-update#06073fa93166277607a7814f4e1f83960081414c"
   dependencies:
@@ -7229,13 +7212,6 @@ log-symbols@^2.0.0, log-symbols@^2.2.0:
   dependencies:
     chalk "^2.0.1"
 
-log-update@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
-  dependencies:
-    ansi-escapes "^1.0.0"
-    cli-cursor "^1.0.2"
-
 log-update@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/log-update/-/log-update-2.3.0.tgz#88328fd7d1ce7938b29283746f0b1bc126b24708"
@@ -7252,7 +7228,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
@@ -7712,6 +7688,11 @@ neo-async@^2.5.0:
 nested-object-assign@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/nested-object-assign/-/nested-object-assign-1.0.3.tgz#5aca69390d9affe5a612152b5f0843ae399ac597"
+
+next-redux-wrapper@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/next-redux-wrapper/-/next-redux-wrapper-2.0.0.tgz#74587381ff9c762cd85676d9739a51a3aeceed58"
+  integrity sha512-QcaEK7pUelShCk6Epajvp3MZrktt/0bVR0f2ssaZtQ270q80zLhKIKFkVZL8uwqXMnSJInZDSwcAhYhn8/Rpsw==
 
 next-tick@1:
   version "1.0.0"
@@ -9569,6 +9550,23 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^0.4.2"
 
+redux-devtools-extension@^2.13.5:
+  version "2.13.5"
+  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.5.tgz#3ff34f7227acfeef3964194f5f7fc2765e5c5a39"
+  integrity sha512-QQ9BRy77oURHMdGys9rfQcCQDzXZ1T4oW+eUyE5Cg7DNVau69HJzc4YNDMOmpi0Dzpi1zOQgQ2rUpgJta4Lfqg==
+
+redux-mock-store@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.3.tgz#1f10528949b7ce8056c2532624f7cafa98576c6d"
+  integrity sha512-ryhkkb/4D4CUGpAV2ln1GOY/uh51aczjcRz9k2L2bPx/Xja3c5pSGJJPyR25GNVRXtKIExScdAgFdiXp68GmJA==
+  dependencies:
+    lodash.isplainobject "^4.0.6"
+
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
+
 redux@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
@@ -9577,6 +9575,14 @@ redux@^3.7.2:
     lodash-es "^4.2.1"
     loose-envify "^1.1.0"
     symbol-observable "^1.0.3"
+
+redux@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"
+  integrity sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==
+  dependencies:
+    loose-envify "^1.4.0"
+    symbol-observable "^1.2.0"
 
 reflect.ownkeys@^0.2.0:
   version "0.2.0"
@@ -10731,7 +10737,7 @@ svgo@^0.7.0, svgo@^0.7.2:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-symbol-observable@^1.0.3, symbol-observable@^1.1.0:
+symbol-observable@^1.0.3, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 


### PR DESCRIPTION
# Description of changes
This work is in preparation of Redux integration. We'll be using to create a window resize listener to give a JS way of determining viewport size.

A lot of this stuff gets solved with other technologies, but using vanilla CSS is the hill we've chosen to die on 💀...

The flow with which our theme propagates:
- Create a new CSS variable
- Variables exported for JS consumption to `common/styles/themeMap.js`
- Variables categorized/sorted/filtered and exported as modules.
- Modules consumed at-will. (Example: colors object consumed in Storybook backgrounds addon)

This process keeps our style-related JS and CSS variables in sync 🔄 

# Issue Resolved
<!-- Keeping the format 'Fixes #{ISSUE_NUMBER}' will automatically close the issue when this PR is merged -->
- Generates breakpoints for consumption in redux PR coming next
- Refactors style export sysem
- Add comments