### PR TITLE
Use postcss.config.js inside Storybook

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const svgoConfig = require('../common/config/svgo');
+const postCSSConfig = require('../postcss.config');
 
 // Export a function. Accept the base config as the only param.
 module.exports = (storybookBaseConfig, configType) => {
@@ -27,12 +28,18 @@ module.exports = (storybookBaseConfig, configType) => {
           loader: 'postcss-loader',
           options: {
             plugins: [
-              require('postcss-import')({ root: path.join(__dirname, '../') }),
+              // Use PostCSS.config.js, but also use `postcss-export-custom-variables` plugin
+              ...postCSSConfig({
+                file: {
+                  dirname: '../',
+                },
+                options: storybookBaseConfig,
+                env: configType.toLowerCase(),
+              }).plugins,
               require('postcss-export-custom-variables')({
                 exporter: 'js',
                 destination: 'common/styles/themeMap.js',
               }),
-              require('autoprefixer')(),
             ],
           },
         },

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,12 +1,9 @@
 /* eslint-disable global-require */
-module.exports = ({ file, options /* env is also available */ }) => {
-  const plugins = {
-    'postcss-import': { root: file.dirname },
-    autoprefixer: {
-      ...options.autoprefixer,
-      flexbox: 'no-2009',
-    },
-  };
+module.exports = ({ file, options, env }) => {
+  const ENV = env.toLowerCase(); // eslint-disable-line no-unused-vars
 
-  return { plugins };
+  return {
+    ...options,
+    plugins: [require('postcss-import')({ root: file.dirname }), require('autoprefixer')()],
+  };
 };


### PR DESCRIPTION
# Description of changes
We were defining PostCSS rulesets in two places which is an error-prone practice. Storybook _IS_ using a plugin not used by the application, but this change still ensures that both the app and storybook are getting their PostCSS rulesets from the same place.
