### PR TITLE
Login page

### DIFF
--- a/common/constants/api.js
+++ b/common/constants/api.js
@@ -21,6 +21,14 @@ export const createUser = ({ email, password, firstName, lastName, zipcode }) =>
     },
   }).then(({ data }) => data);
 
+export const loginUser = ({ email, password }) =>
+  post('sessions', {
+    user: {
+      email,
+      password,
+    },
+  }).then(({ data }) => data);
+
 export const postMentorRequestPromise = ({ language, additionalDetails, mentor, service }) =>
   post('requests', {
     request: {

--- a/common/utils/api-utils.js
+++ b/common/utils/api-utils.js
@@ -6,7 +6,14 @@ export const OperationCodeAPI = axios.create({ baseURL: apiUrl });
 
 const setAuthorizationHeader = () => {
   const cookies = new Cookies();
-  return { Authorization: `bearer ${cookies.get('token')}` };
+
+  const token = cookies.get('token');
+
+  if (token) {
+    return { Authorization: `bearer ${cookies.get('token')}` };
+  }
+
+  return {};
 };
 
 export const get = async path => {

--- a/common/utils/cookie-utils.js
+++ b/common/utils/cookie-utils.js
@@ -1,52 +1,30 @@
 import Cookies from 'universal-cookie';
 import jwt_decode from 'jwt-decode'; // eslint-disable-line camelcase
 
-const cookieDomain = () => {
-  if (process.env.NODE_ENV === 'development') {
-    return 'localhost';
-  }
-  return 'operationcode.org';
+const cookieOptions = {
+  path: '/',
+  domain: process.env.NODE_ENV === 'development' ? 'localhost' : 'operationcode.org',
 };
 
-const cookieOptions = { path: '/', domain: cookieDomain() };
-
-export const setUserAuthCookie = ({ token, user }) => {
+export const loginCookies = ({ token, user }) => {
   const cookies = new Cookies();
   cookies.set('token', token, cookieOptions);
   cookies.set('firstName', user.first_name, cookieOptions);
   cookies.set('lastName', user.last_name, cookieOptions);
   cookies.set('slackName', user.slack_name, cookieOptions);
   cookies.set('mentor', user.mentor, cookieOptions);
-  cookies.set('verified', user.verified, cookieOptions);
 };
 
-export const setUserVerifiedCookie = isVerified => {
-  const cookies = new Cookies();
-  cookies.set('verified', isVerified, cookieOptions);
-};
-
-export const clearAuthCookies = () => {
+export const logoutCookies = () => {
   const cookies = new Cookies();
   cookies.remove('token', cookieOptions);
   cookies.remove('firstName', cookieOptions);
   cookies.remove('lastName', cookieOptions);
   cookies.remove('slackName', cookieOptions);
   cookies.remove('mentor', cookieOptions);
-  cookies.remove('verified', cookieOptions);
 };
 
-export const isMentor = () => {
-  const cookies = new Cookies();
-  return cookies.get('mentor');
-};
-
-export const authToken = () => {
-  const cookies = new Cookies();
-  const token = cookies.get('token');
-  return token;
-};
-
-const validToken = token => {
+const isTokenValid = token => {
   if (token === undefined) {
     return false;
   }
@@ -54,19 +32,15 @@ const validToken = token => {
   const jwt = jwt_decode(token);
   const currentTime = new Date().getTime() / 1000;
 
-  if (currentTime > jwt.exp) {
-    return false;
-  }
-
-  return true;
+  // Valid if jwt expiry is in the future
+  return currentTime < jwt.exp;
 };
 
 export const getUserStatus = () => {
   const cookies = new Cookies();
 
   return {
-    mentor: cookies.get('mentor') === 'true',
-    signedIn: validToken(cookies.get('token')),
-    verified: cookies.get('verified') === 'true',
+    isMentor: cookies.get('mentor') === 'true',
+    isLoggedIn: isTokenValid(cookies.get('token')),
   };
 };

--- a/components/Button/Button.css
+++ b/components/Button/Button.css
@@ -60,7 +60,3 @@
 a.Button {
   font-family: var(--primaryFontFamily), sans-serif;
 }
-
-.Button[type="submit"] {
-  margin-top: 1rem;
-}

--- a/components/Button/Button.css
+++ b/components/Button/Button.css
@@ -60,3 +60,7 @@
 a.Button {
   font-family: var(--primaryFontFamily), sans-serif;
 }
+
+.Button[type="submit"] {
+  margin-top: 1rem;
+}

--- a/components/Form/Input/Input.css
+++ b/components/Form/Input/Input.css
@@ -36,3 +36,11 @@
   box-shadow: 0 0 1px 1px var(--errorDeep);
   outline: none;
 }
+
+.input:disabled {
+  opacity: 0.6;
+}
+
+.input:disabled:hover {
+  cursor: not-allowed;
+}

--- a/components/LoginForm/LoginForm.css
+++ b/components/LoginForm/LoginForm.css
@@ -1,0 +1,9 @@
+.LoginForm {
+  width: 100%;
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}

--- a/components/LoginForm/LoginForm.css
+++ b/components/LoginForm/LoginForm.css
@@ -7,3 +7,7 @@
   flex-wrap: wrap;
   justify-content: center;
 }
+
+.topMargin {
+  margin-top: 1rem;
+}

--- a/components/LoginForm/LoginForm.js
+++ b/components/LoginForm/LoginForm.js
@@ -103,7 +103,12 @@ class LoginForm extends Component {
             </div>
 
             <div className={styles.row}>
-              <Button type="submit" theme="secondary" disabled={isSubmitting}>
+              <Button
+                className={styles.topMargin}
+                type="submit"
+                theme="secondary"
+                disabled={isSubmitting}
+              >
                 Submit
               </Button>
             </div>

--- a/components/LoginForm/LoginForm.js
+++ b/components/LoginForm/LoginForm.js
@@ -1,0 +1,117 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Formik, Field } from 'formik';
+import * as Yup from 'yup';
+import { minPasswordCharNum, validationErrorMessages } from 'common/constants/validations';
+import { isMinPasswordStrength } from 'common/utils/validator-utils';
+import Button from 'components/Button/Button';
+import Form from 'components/Form/Form';
+import Input from 'components/Form/Input/Input';
+import Alert from 'components/Alert/Alert';
+import styles from './LoginForm.css';
+
+/*
+ * NOTE: We're repeating hardcode between the registration schema and passing an asterisk
+ * to the label of required fields. This seems to an unfortunate negative aspect of an otherwise
+ * awesome library. More importantly, it looks like the lib's author has plans to remedy the
+ * situation. For now, our forms wont change much, so we should be okay.
+ */
+const loginSchema = Yup.object().shape({
+  email: Yup.string()
+    .required(validationErrorMessages.required)
+    .email(validationErrorMessages.email),
+  password: Yup.string()
+    .required(validationErrorMessages.required)
+    .min(minPasswordCharNum, validationErrorMessages.length(minPasswordCharNum))
+    .test('password-strength', validationErrorMessages.password, isMinPasswordStrength),
+});
+
+// TODO: Define links for terms of service / privacy policy and place on this page
+class LoginForm extends Component {
+  static propTypes = {
+    login: PropTypes.func.isRequired, // essentially onSubmit
+    onSuccess: PropTypes.func.isRequired,
+    initialValues: PropTypes.shape({
+      email: PropTypes.string,
+      password: PropTypes.string,
+    }),
+  };
+
+  static defaultProps = {
+    initialValues: {
+      email: '',
+      password: '',
+    },
+  };
+
+  state = {
+    errorMsg: '',
+  };
+
+  handleSubmit = async (values, actions) => {
+    const { login, onSuccess } = this.props;
+
+    try {
+      await login(values);
+      actions.setSubmitting(false);
+      actions.resetForm();
+
+      await onSuccess();
+    } catch (error) {
+      actions.setSubmitting(false);
+
+      const { data } = error.response;
+      this.setState({ errorMsg: data.error });
+    }
+  };
+
+  render() {
+    const { props, state } = this;
+
+    return (
+      <Formik
+        initialValues={props.initialValues}
+        onSubmit={this.handleSubmit}
+        validationSchema={loginSchema}
+      >
+        {({ isSubmitting }) => (
+          <Form className={styles.LoginForm}>
+            <div className={styles.row}>
+              <Field
+                type="email"
+                name="email"
+                label="Email*"
+                component={Input}
+                disabled={isSubmitting}
+                autoComplete="username email"
+              />
+
+              <Field
+                type="password"
+                name="password"
+                label="Password*"
+                component={Input}
+                disabled={isSubmitting}
+                autoComplete="new-password"
+              />
+            </div>
+
+            <div className={styles.row}>
+              <Alert isOpen={Boolean(state.errorMsg)} type="error">
+                {state.errorMsg}
+              </Alert>
+            </div>
+
+            <div className={styles.row}>
+              <Button type="submit" theme="secondary" disabled={isSubmitting}>
+                Submit
+              </Button>
+            </div>
+          </Form>
+        )}
+      </Formik>
+    );
+  }
+}
+
+export default LoginForm;

--- a/components/LoginForm/__tests__/LoginForm.test.js
+++ b/components/LoginForm/__tests__/LoginForm.test.js
@@ -1,0 +1,164 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { loginUser } from 'common/constants/api';
+import { validationErrorMessages } from 'common/constants/validations';
+import createSnapshotTest from 'test-utils/createSnapshotTest';
+import OperationCodeAPIMock from 'test-utils/mocks/apiMock';
+import wait from 'test-utils/wait';
+import LoginForm from '../LoginForm';
+
+const asyncRenderDiff = async enzymeWrapper => {
+  await wait();
+  enzymeWrapper.update();
+};
+
+afterEach(() => {
+  OperationCodeAPIMock.reset();
+});
+
+describe('LoginForm', () => {
+  it('should render with required props', () => {
+    createSnapshotTest(<LoginForm login={jest.fn()} onSuccess={jest.fn()} />);
+  });
+
+  it('should display required error message when blurring past email input', async () => {
+    const wrapper = mount(<LoginForm login={jest.fn()} onSuccess={jest.fn()} />);
+
+    wrapper.find('input#email').simulate('blur');
+
+    await asyncRenderDiff(wrapper);
+
+    expect(
+      wrapper
+        .find('Input[type="email"]')
+        .find('Alert')
+        .text(),
+    ).toStrictEqual(validationErrorMessages.required);
+  });
+
+  it('should show error when providing non-email to email input', async () => {
+    const wrapper = mount(<LoginForm login={jest.fn()} onSuccess={jest.fn()} />);
+
+    wrapper
+      .find('input#email')
+      .simulate('change', { target: { id: 'email', value: 'email' } })
+      .simulate('blur');
+
+    await asyncRenderDiff(wrapper);
+
+    expect(
+      wrapper
+        .find('Input[type="email"]')
+        .find('Alert')
+        .text(),
+    ).toStrictEqual(validationErrorMessages.email);
+  });
+
+  it('should show "password required" message when blurring past input', async () => {
+    const wrapper = mount(<LoginForm login={jest.fn()} onSuccess={jest.fn()} />);
+
+    wrapper.find('input#password').simulate('blur');
+
+    await asyncRenderDiff(wrapper);
+
+    expect(
+      wrapper
+        .find('Input[type="password"]')
+        .find('Alert')
+        .text(),
+    ).toStrictEqual(validationErrorMessages.required);
+  });
+
+  it('should show "invalid password" message when focusing off an invalid password', async () => {
+    const wrapper = mount(<LoginForm login={jest.fn()} onSuccess={jest.fn()} />);
+
+    const stringWithNoCapital = 'sillypassword1';
+
+    wrapper
+      .find('input#password')
+      .simulate('change', { target: { id: 'password', value: stringWithNoCapital } })
+      .simulate('blur');
+
+    await asyncRenderDiff(wrapper);
+
+    expect(
+      wrapper
+        .find('Input[type="password"]')
+        .find('Alert')
+        .text(),
+    ).toStrictEqual(validationErrorMessages.password);
+  });
+
+  it('should submit with valid data in form', async () => {
+    const successSpy = jest.fn();
+    const wrapper = mount(
+      <LoginForm
+        onSuccess={successSpy}
+        login={jest.fn()}
+        initialValues={{
+          email: 'email@email.com',
+          password: 'abc123ABC',
+        }}
+      />,
+    );
+
+    wrapper.find('Button').simulate('submit');
+    await asyncRenderDiff(wrapper);
+
+    expect(successSpy).toHaveBeenCalled();
+  });
+
+  it('should NOT submit with invalid data in form', async () => {
+    const successSpy = jest.fn();
+
+    const wrapper = mount(
+      <LoginForm
+        onSuccess={successSpy}
+        login={jest.fn()}
+        initialValues={{
+          email: 'email@email',
+          password: '1',
+        }}
+      />,
+    );
+
+    wrapper.find('Button').simulate('submit');
+    await asyncRenderDiff(wrapper);
+
+    expect(successSpy).not.toHaveBeenCalled();
+  });
+
+  it('should show error when trying to login with incorrect email or password', async () => {
+    const invalidError = 'Invalid Email or password.';
+
+    const user = {
+      email: 'testing123@gmail.com',
+      password: 'Testing123',
+    };
+
+    OperationCodeAPIMock.onPost('sessions', { user }).reply(401, { error: invalidError });
+
+    const successSpy = jest.fn();
+
+    const wrapper = mount(
+      <LoginForm
+        login={loginUser}
+        onSuccess={successSpy}
+        initialValues={{
+          ...user,
+        }}
+      />,
+    );
+
+    wrapper.find('Button').simulate('submit');
+    await asyncRenderDiff(wrapper);
+
+    expect(successSpy).not.toHaveBeenCalled();
+    expect(
+      wrapper
+        .find('Alert')
+        .last()
+        .text(),
+    ).toStrictEqual(invalidError);
+  });
+});

--- a/components/LoginForm/__tests__/__snapshots__/LoginForm.test.js.snap
+++ b/components/LoginForm/__tests__/__snapshots__/LoginForm.test.js.snap
@@ -75,7 +75,7 @@ exports[`LoginForm should render with required props 1`] = `
     className="row"
   >
     <button
-      className="Button secondary"
+      className="Button topMargin secondary"
       disabled={false}
       onClick={[Function]}
       tabIndex={0}

--- a/components/LoginForm/__tests__/__snapshots__/LoginForm.test.js.snap
+++ b/components/LoginForm/__tests__/__snapshots__/LoginForm.test.js.snap
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LoginForm should render with required props 1`] = `
+<form
+  className="LoginForm"
+  noValidate={true}
+  onReset={[Function]}
+  onSubmit={[Function]}
+>
+  <div
+    className="row"
+  >
+    <div
+      className="field"
+    >
+      <label
+        className="Label"
+        htmlFor="email"
+      >
+        Email*
+      </label>
+      <div
+        className="inputFeedBackGrouping"
+      >
+        <input
+          autoComplete="username email"
+          className="input"
+          disabled={false}
+          id="email"
+          name="email"
+          onBlur={[Function]}
+          onChange={[Function]}
+          type="email"
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      className="field"
+    >
+      <label
+        className="Label"
+        htmlFor="password"
+      >
+        Password*
+      </label>
+      <div
+        className="inputFeedBackGrouping"
+      >
+        <input
+          autoComplete="new-password"
+          className="input"
+          disabled={false}
+          id="password"
+          name="password"
+          onBlur={[Function]}
+          onChange={[Function]}
+          type="password"
+          value=""
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className="row"
+  >
+    <div
+      className="Alert error"
+      role="alert"
+    >
+      
+    </div>
+  </div>
+  <div
+    className="row"
+  >
+    <button
+      className="Button secondary"
+      disabled={false}
+      onClick={[Function]}
+      tabIndex={0}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;

--- a/components/RegistrationForm/RegistrationForm.css
+++ b/components/RegistrationForm/RegistrationForm.css
@@ -1,9 +1,9 @@
+.RegistrationForm {
+  width: 100%;
+}
+
 .row {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-}
-
-.topSpacing {
-  margin-top: 1rem;
 }

--- a/components/RegistrationForm/RegistrationForm.css
+++ b/components/RegistrationForm/RegistrationForm.css
@@ -7,3 +7,7 @@
   flex-wrap: wrap;
   justify-content: center;
 }
+
+.topMargin {
+  margin-top: 1rem;
+}

--- a/components/RegistrationForm/RegistrationForm.js
+++ b/components/RegistrationForm/RegistrationForm.js
@@ -189,7 +189,12 @@ class RegistrationForm extends Component {
             </div>
 
             <div className={styles.row}>
-              <Button type="submit" theme="secondary" disabled={isSubmitting}>
+              <Button
+                className={styles.topMargin}
+                type="submit"
+                theme="secondary"
+                disabled={isSubmitting}
+              >
                 Submit
               </Button>
             </div>

--- a/components/RegistrationForm/RegistrationForm.js
+++ b/components/RegistrationForm/RegistrationForm.js
@@ -110,7 +110,7 @@ class RegistrationForm extends Component {
         validationSchema={registrationSchema}
       >
         {({ isSubmitting }) => (
-          <Form>
+          <Form className={styles.RegistrationForm}>
             <div className={styles.row}>
               <Field
                 type="email"
@@ -189,12 +189,7 @@ class RegistrationForm extends Component {
             </div>
 
             <div className={styles.row}>
-              <Button
-                className={styles.topSpacing}
-                type="submit"
-                theme="secondary"
-                disabled={isSubmitting}
-              >
+              <Button type="submit" theme="secondary" disabled={isSubmitting}>
                 Submit
               </Button>
             </div>

--- a/components/RegistrationForm/__tests__/RegistrationForm.test.js
+++ b/components/RegistrationForm/__tests__/RegistrationForm.test.js
@@ -167,7 +167,7 @@ describe('RegistrationForm', () => {
   });
 
   it('should show "email already registered" message for dupe email registration', async () => {
-    const user = {
+    const testUser = {
       email: 'kylemh.email12@gmail.com',
       password: 'Testing123!',
       firstName: 'Test',
@@ -175,7 +175,15 @@ describe('RegistrationForm', () => {
       zipcode: 90630,
     };
 
-    OperationCodeAPIMock.onAny().reply(422, { email: ['has been taken'] });
+    OperationCodeAPIMock.onPost('users', {
+      user: {
+        email: testUser.email,
+        password: testUser.password,
+        first_name: testUser.firstName,
+        last_name: testUser.lastName,
+        zip: testUser.zipcode,
+      },
+    }).reply(422, { email: ['has been taken'] });
 
     const successSpy = jest.fn();
     const wrapper = mount(
@@ -183,9 +191,9 @@ describe('RegistrationForm', () => {
         register={createUser}
         onSuccess={successSpy}
         initialValues={{
-          ...user,
-          'confirm-email': user.email,
-          'confirm-password': user.password,
+          ...testUser,
+          'confirm-email': testUser.email,
+          'confirm-password': testUser.password,
         }}
       />,
     );

--- a/components/RegistrationForm/__tests__/RegistrationForm.test.js
+++ b/components/RegistrationForm/__tests__/RegistrationForm.test.js
@@ -166,7 +166,6 @@ describe('RegistrationForm', () => {
     expect(successSpy).not.toHaveBeenCalled();
   });
 
-  // TODO: Get this integration test working
   it('should show "email already registered" message for dupe email registration', async () => {
     const user = {
       email: 'kylemh.email12@gmail.com',

--- a/components/RegistrationForm/__tests__/__snapshots__/RegistrationForm.test.js.snap
+++ b/components/RegistrationForm/__tests__/__snapshots__/RegistrationForm.test.js.snap
@@ -212,7 +212,7 @@ exports[`RegistrationForm should render with required props 1`] = `
     className="row"
   >
     <button
-      className="Button secondary"
+      className="Button topMargin secondary"
       disabled={false}
       onClick={[Function]}
       tabIndex={0}

--- a/components/RegistrationForm/__tests__/__snapshots__/RegistrationForm.test.js.snap
+++ b/components/RegistrationForm/__tests__/__snapshots__/RegistrationForm.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`RegistrationForm should render with required props 1`] = `
 <form
+  className="RegistrationForm"
   noValidate={true}
   onReset={[Function]}
   onSubmit={[Function]}
@@ -211,7 +212,7 @@ exports[`RegistrationForm should render with required props 1`] = `
     className="row"
   >
     <button
-      className="Button topSpacing secondary"
+      className="Button secondary"
       disabled={false}
       onClick={[Function]}
       tabIndex={0}

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,6 +41,7 @@ module.exports = {
 
     // No real logic to test here
     '<rootDir>/common/utils/api-utils.js',
+    '<rootDir>/common/utils/cookie-utils.js',
     '<rootDir>/components/FAQ/questions.js',
     '<rootDir>/components/ZipRecruiterJobs/ZipRecruiterJobs.js',
     '<rootDir>/components/Press/PressLinks/Articles.js',

--- a/pages/join.js
+++ b/pages/join.js
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import Router from 'next/router';
 import { createUser } from 'common/constants/api';
 import Head from 'components/head';
@@ -15,6 +16,13 @@ export default () => (
       theme="gray"
       columns={[
         <RegistrationForm register={createUser} onSuccess={() => Router.push('/profile')} />,
+        <p>
+          Already registered?&nbsp;
+          <Link href="/login">
+            <a>Login</a>
+          </Link>
+          .
+        </p>,
       ]}
     />
   </>

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,6 +1,10 @@
+import Link from 'next/link';
+import Router from 'next/router';
+import { loginUser } from 'common/constants/api';
 import Head from 'components/head';
 import HeroBanner from 'components/HeroBanner/HeroBanner';
 import Content from 'components/Content/Content';
+import LoginForm from 'components/LoginForm/LoginForm';
 
 export default () => (
   <>
@@ -8,6 +12,25 @@ export default () => (
 
     <HeroBanner title="Login" />
 
-    <Content theme="gray" columns={[<p>Under construction!</p>]} />
+    <Content
+      theme="gray"
+      columns={[
+        <LoginForm login={loginUser} onSuccess={() => Router.push('/profile')} />,
+        <p>
+          Don&apos;t have an account?&nbsp;
+          <Link href="/join">
+            <a>Register</a>
+          </Link>
+          .
+        </p>,
+        <p>
+          Forgot your password?&nbsp;
+          <Link href="/reset_password">
+            <a>Reset it</a>
+          </Link>
+          .
+        </p>,
+      ]}
+    />
   </>
 );

--- a/pages/reset_password.js
+++ b/pages/reset_password.js
@@ -1,0 +1,13 @@
+import Head from 'components/head';
+import HeroBanner from 'components/HeroBanner/HeroBanner';
+import Content from 'components/Content/Content';
+
+export default () => (
+  <>
+    <Head title="ResetPassword" />
+
+    <HeroBanner title="ResetPassword" />
+
+    <Content theme="gray" columns={[<p>Under construction...</p>]} />
+  </>
+);


### PR DESCRIPTION
# Description of changes
- Refactor cookies utils
- Style disabled inputs
- Polish /login page
- Create /reset_password page (just the route)
- Improve <RegistrationForm> network integration test

## What's Next?
- Now that we have login/registration flows... We need to ensure cookies are matching up with authentication states and prove it with an authenticated route (namely: `/profile`)

## Screenshots/GIFs
![Screen Shot 2019-03-12 at 12 34 12 AM](https://user-images.githubusercontent.com/9523719/54182373-93df2480-445e-11e9-8147-b2db1325bd77.png)