### PR TITLE
Replace unnecessary fill from currentColor if necessary

### DIFF
--- a/components/Cards/SchoolCard/FrontSchoolCard.css
+++ b/components/Cards/SchoolCard/FrontSchoolCard.css
@@ -40,17 +40,14 @@
 
 .active {
   color: var(--secondary);
-  fill: var(--secondary);
 }
 
 .disabled {
   color: var(--gray);
-  fill: var(--gray);
 }
 
 .codeSchoolCardIcon > img,
 .codeSchoolCardIcon > svg {
-  fill: currentColor;
   height: 50px;
   margin: 1rem 0;
 }

--- a/components/Container/Container.css
+++ b/components/Container/Container.css
@@ -7,6 +7,7 @@
   justify-content: center;
   min-height: 250px;
   width: 100%;
+  fill: currentColor;
 }
 
 /* need to have a higher order of specificity since HeroBanner fights it */
@@ -28,18 +29,15 @@
 .secondary {
   background-color: var(--secondary);
   color: var(--white);
-  fill: var(--white);
 }
 
 /* Light Themes */
 .gray {
   background-color: var(--gray);
   color: var(--secondary);
-  fill: var(--secondary);
 }
 
 .white {
   background-color: var(--white);
   color: var(--secondary);
-  fill: var(--secondary);
 }

--- a/components/Nav/NavListItem/NavListItem.css
+++ b/components/Nav/NavListItem/NavListItem.css
@@ -13,7 +13,7 @@
   align-items: center;
   color: var(--secondary);
   display: flex;
-  fill: var(--secondary);
+  fill: currentColor;
   height: 100%;
   justify-content: center;
   transition: all 0.2s linear;
@@ -37,7 +37,6 @@
 .NavListItem:hover .sublinkToggleButton:not(.sublinkListItem) {
   cursor: pointer;
   color: var(--primary);
-  fill: var(--primary);
   transition: all 0.2s linear;
 }
 

--- a/pages/styles/events.css
+++ b/pages/styles/events.css
@@ -34,7 +34,6 @@
 }
 
 .badge {
-  fill: var(--secondary);
   margin: 1rem 4rem;
 }
 

--- a/pages/styles/get_involved.css
+++ b/pages/styles/get_involved.css
@@ -30,7 +30,6 @@
 }
 
 .badge {
-  fill: var(--secondary);
   margin: 1rem 4rem;
 }
 


### PR DESCRIPTION
# Description of changes

Replace any unnecessary `fill` styling for SVG's that were being handled with `currentColor`. See #383 for more info.

# Issue Resolved
<!-- Keeping the format 'Fixes #{ISSUE_NUMBER}' will automatically close the issue when this PR is merged -->
Fixes #383
