### PR TITLE
Fix overflow height

### DIFF
--- a/components/FAQ/FAQItem/FAQItem.css
+++ b/components/FAQ/FAQItem/FAQItem.css
@@ -6,13 +6,12 @@
   margin-top: 5px;
   max-height: 0;
   opacity: 0;
-  transform: translate(0, 5%);
   transition: all 0.4s ease;
   position: relative;
 }
 
 .accordionSingleHidden:checked ~ .accordionSingleAnswer {
-  max-height: 600px;
+  max-height: 1000px;
   opacity: 1;
   margin-top: 14px;
 }


### PR DESCRIPTION
# Description of changes

Fix overflow height for FAQ items. FAQ items cutting off height of extra long text boxes.

## Screenshots/GIFs

![screenshot_20190407-175906](https://user-images.githubusercontent.com/2691129/55702534-ddab2400-59a4-11e9-98ba-08da9ab16645.png)

