### PR TITLE
Remove cookie options

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -113,6 +113,12 @@
       }
     },
     {
+      "files": ["*.spec.js"],
+      "rules": {
+        "no-unused-expressions": ["off"]
+      }
+    },
+    {
       "files": [
         "pages/**.js",
         "components/head.js",

--- a/common/utils/cookie-utils.js
+++ b/common/utils/cookie-utils.js
@@ -1,23 +1,13 @@
 import cookie from 'js-cookie';
 import jwt_decode from 'jwt-decode'; // eslint-disable-line camelcase
 
-const isProd = process.env.NODE_ENV !== 'development';
-
-const cookieOptions = {
-  path: '/',
-  domain: isProd ? 'operation-code.now.sh' : 'localhost',
-  httpOnly: isProd,
-  sameSite: isProd,
-  secure: isProd,
-};
-
-const userInfoCookieNames = ['firstName', 'lastName', 'zipcode'];
+const userInfoCookieNames = ['firstName', 'lastName', 'zipcode', 'isMentor'];
 
 export const setAuthCookies = ({ token, user }) => {
-  cookie.set('token', token, cookieOptions);
+  cookie.set('token', token);
 
   userInfoCookieNames.forEach(cookieName => {
-    cookie.set(cookieName, user[cookieName], cookieOptions);
+    cookie.set(cookieName, user[cookieName]);
   });
 };
 

--- a/cypress/integration/login.spec.js
+++ b/cypress/integration/login.spec.js
@@ -17,13 +17,14 @@ describe('login', function() {
     cy.url().should('contain', '/profile');
     cy.get('h1').should('have.text', 'Profile');
     cy.get('p').contains('Hello Kyle Holmberg!');
-    cy.getCookies()
-      .should('have.length', 4)
-      .then(cookies => {
-        expect(cookies[0].value).to.contain('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9');
-        expect(cookies[1].value).to.equal('Kyle');
-        expect(cookies[2].value).to.equal('Holmberg');
-        expect(cookies[3].value).to.equal('97214');
-      });
+
+    cy.getCookies().then(cookies => {
+      expect(
+        cookies.some(({ value }) => value.includes('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9')),
+      ).to.equal(true);
+      expect(cookies.some(({ value }) => value === 'Kyle')).to.be.true;
+      expect(cookies.some(({ value }) => value === 'Holmberg')).to.be.true;
+      expect(cookies.some(({ value }) => value === '97214')).to.be.true;
+    });
   });
 });

--- a/cypress/integration/register.spec.js
+++ b/cypress/integration/register.spec.js
@@ -37,12 +37,11 @@ describe('register', function() {
     cy.url().should('contain', '/profile');
     cy.get('h1').should('have.text', 'Profile');
     cy.get('p').contains(`Hello ${newUser.firstName} ${newUser.lastName}!`);
-    cy.getCookies()
-      .should('have.length', 4)
-      .then(cookies => {
-        expect(cookies[1].value).to.equal(newUser.firstName);
-        expect(cookies[2].value).to.equal(newUser.lastName);
-        expect(cookies[3].value).to.equal(`${newUser.zipcode}`); // number to string 🤷‍♂️
-      });
+
+    cy.getCookies().then(cookies => {
+      expect(cookies.some(({ value }) => value === newUser.firstName)).to.be.true;
+      expect(cookies.some(({ value }) => value === newUser.lastName)).to.be.true;
+      expect(cookies.some(({ value }) => value === newUser.zipcode.toString())).to.be.true;
+    });
   });
 });


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
We're using JWT, and storing cookies on the client. It's okay to store them insecurely, because we're only using them in headers in requests. It's up to the server to determine if they're valid.

Aside: Cypress uses Chai assertions which cause an ESLint error to go off. So, I've added an override of the rule for `*.spec.js` files.

# Issue Resolved
<!-- Keeping the format 'Fixes #{ISSUE_NUMBER}' will automatically close the issue when this PR is merged -->
Hopefully fixes logging in and registration
