### PR TITLE
Fixed bug 437 - initial state not resetting after cleared state field

### DIFF
--- a/pages/code_schools.js
+++ b/pages/code_schools.js
@@ -62,7 +62,11 @@ export default class CodeSchools extends React.Component {
       school.locations.some(location => states.includes(location.state)),
     );
 
-    this.setState({ filteredSchools: stateSchools, selectedStates: selectedOptions });
+    if (states.length > 0) {
+      this.setState({ filteredSchools: stateSchools, selectedStates: selectedOptions });
+    } else {
+      this.showAllSchools();
+    }
   };
 
   filterVaApproved = () => {


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Added a conditional (lines 65-69) to the filterState method in code_schools.js to reset state back to initial state once a user cleared all States (e.g. GA or MA) from the Select States bar.

# Issue Resolved
<!-- Keeping the format 'Fixes #{ISSUE_NUMBER}' will automatically close the issue when this PR is merged -->
Fixes #437 

## Screenshots/GIFs
<!-- Please provide a view into the feature/bugfix if possible-->
![Bug 437 Fix](https://media.giphy.com/media/c6Xs8OMuUYAcoE1hdg/giphy.gif)