### PR TITLE
Improve error message in style utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ out
 
 # WebStorm Config
 .idea
+
+# File system stuff
+.DS_Store

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const svgoConfig = require('../common/config/svgo');
 const postCSSConfig = require('../postcss.config');
+const { insertIf } = require('../common/utils/array-utils');
 
 // Export a function. Accept the base config as the only param.
 module.exports = (storybookBaseConfig, configType) => {
@@ -28,7 +29,7 @@ module.exports = (storybookBaseConfig, configType) => {
           loader: 'postcss-loader',
           options: {
             plugins: [
-              // Use PostCSS.config.js, but also use `postcss-export-custom-variables` plugin
+              // Use PostCSS.config.js, but also use `postcss-export-custom-variables` plugin in dev
               ...postCSSConfig({
                 file: {
                   dirname: '../',
@@ -36,10 +37,13 @@ module.exports = (storybookBaseConfig, configType) => {
                 options: storybookBaseConfig,
                 env: configType.toLowerCase(),
               }).plugins,
-              require('postcss-export-custom-variables')({
-                exporter: 'js',
-                destination: 'common/styles/themeMap.js',
-              }),
+              ...insertIf(
+                configType === 'DEVELOPMENT',
+                require('postcss-export-custom-variables')({
+                  exporter: 'js',
+                  destination: 'common/styles/themeMap.js',
+                }),
+              ),
             ],
           },
         },

--- a/common/styles/styleExports.js
+++ b/common/styles/styleExports.js
@@ -15,12 +15,7 @@ export const breakpointsObject = themeMapValues.reduce((obj, [key, value]) => {
 
 export const brandColorsObject = themeMapValues.reduce((obj, [key, value]) => {
   if (isHexColor(value)) {
-    // We don't want to include modifier colors like `primaryLight`
-    const isBrandColor = !(key.includes('Light') || key.includes('Dark'));
-
-    if (isBrandColor) {
-      obj[key] = value; // eslint-disable-line no-param-reassign
-    }
+    obj[key] = value; // eslint-disable-line no-param-reassign
   }
 
   return obj;

--- a/common/utils/__tests__/array-utils.test.js
+++ b/common/utils/__tests__/array-utils.test.js
@@ -1,0 +1,20 @@
+import { insertIf } from '../array-utils';
+
+describe('Array Utilities', () => {
+  describe('insertIf', () => {
+    it('should return an empty array if condition is false', () => {
+      const someEmptyArray = [];
+
+      expect(insertIf(false, someEmptyArray)).toStrictEqual([]);
+    });
+
+    it('should return an passed argument if condition is true', () => {
+      const someObj = { key: 'value' };
+      expect(insertIf(true, someObj)).toStrictEqual([someObj]);
+    });
+
+    it('should return an array of every argument if condition is true', () => {
+      expect(insertIf(true, 'yo', 'yes', 'wow', 2)).toStrictEqual(['yo', 'yes', 'wow', 2]);
+    });
+  });
+});

--- a/common/utils/__tests__/style-utils.test.js
+++ b/common/utils/__tests__/style-utils.test.js
@@ -58,7 +58,16 @@ describe('Style Utilities', () => {
     });
 
     it('should throw an error if not passed a string', () => {
-      expect(() => isHexColor(3725)).toThrow('Must pass a string to this method.');
+      expect(() => isHexColor(3725)).toThrow(
+        'Must pass a string to this method. You passed 3725 which is type of: number.',
+      );
+    });
+
+    it('should throw an error if not passed a string - specifically an object', () => {
+      const someObject = { someKey: 'value' };
+      const errorMessage = `Must pass a string to this method. You passed an object! Keys: someKey`;
+
+      expect(() => isHexColor(someObject)).toThrow(errorMessage);
     });
   });
 

--- a/common/utils/array-utils.js
+++ b/common/utils/array-utils.js
@@ -1,0 +1,18 @@
+// TODO: Remove once mulitple methods within
+/* eslint-disable import/prefer-default-export */
+
+/**
+ * @description a method to conditionally apply items into an array
+ * @see http://2ality.com/2017/04/conditional-literal-entries.html#variations-of-the-original-approach
+ * @export
+ * @param {boolean} condition
+ * @param {...[]} elements (1 or many arguments which are spread into an array)
+ * @returns {[]}
+ */
+function insertIf(condition, ...elements) {
+  return condition ? elements : [];
+}
+
+module.exports = {
+  insertIf,
+};

--- a/common/utils/style-utils.js
+++ b/common/utils/style-utils.js
@@ -30,26 +30,27 @@ export function hasPixelSuffix(someString) {
  * @description Check to see if a string is a valid hex color
  *
  * @exports
- * @param {string} someString
+ * @param {string} value
  * @throws Will throw an error if method is not passed a string
  * @returns {boolean}
  */
-export function isHexColor(someString) {
-  if (typeof someString !== 'string') {
-    throw new Error('Must pass a string to this method.');
+export function isHexColor(value) {
+  if (typeof value !== 'string') {
+    throw new Error(
+      `Must pass a string to this method. You passed ${value} which is type of: ${typeof value}`,
+    );
   }
 
   // #FFF (smallest possible hex color pattern)
   // #FFFFFF (largest possible hex color pattern)
-  const stringLength = someString.length;
+  const stringLength = value.length;
   if (stringLength !== 4 && stringLength !== 7) {
     return false;
   }
 
   // Edge Cases: If you pass characters unrelated to a hex letter like 'g' or '+'
   // and it begins with a hashtag, you'll get a false-positive
-
-  return someString.startsWith('#');
+  return value.startsWith('#');
 }
 
 /**

--- a/common/utils/style-utils.js
+++ b/common/utils/style-utils.js
@@ -36,9 +36,15 @@ export function hasPixelSuffix(someString) {
  */
 export function isHexColor(value) {
   if (typeof value !== 'string') {
-    throw new Error(
-      `Must pass a string to this method. You passed ${value} which is type of: ${typeof value}`,
-    );
+    if (typeof value === 'object') {
+      throw new Error(
+        `Must pass a string to this method. You passed an object! Keys: ${Object.keys(value)}`,
+      );
+    } else {
+      throw new Error(
+        `Must pass a string to this method. You passed ${value} which is type of: ${typeof value}`,
+      );
+    }
   }
 
   // #FFF (smallest possible hex color pattern)

--- a/common/utils/style-utils.js
+++ b/common/utils/style-utils.js
@@ -37,13 +37,13 @@ export function hasPixelSuffix(someString) {
 export function isHexColor(value) {
   if (typeof value === 'object') {
     throw new Error(
-      `Must pass a string to this method. You passed an object! Keys: ${Object.keys(value)}`,
+      `Must pass a string to this method. You passed an object! Keys: ${Object.keys(value)}.`,
     );
   }
 
   if (typeof value !== 'string') {
     throw new Error(
-      `Must pass a string to this method. You passed ${value} which is type of: ${typeof value}`,
+      `Must pass a string to this method. You passed ${value} which is type of: ${typeof value}.`,
     );
   }
 

--- a/common/utils/style-utils.js
+++ b/common/utils/style-utils.js
@@ -35,16 +35,16 @@ export function hasPixelSuffix(someString) {
  * @returns {boolean}
  */
 export function isHexColor(value) {
+  if (typeof value === 'object') {
+    throw new Error(
+      `Must pass a string to this method. You passed an object! Keys: ${Object.keys(value)}`,
+    );
+  }
+
   if (typeof value !== 'string') {
-    if (typeof value === 'object') {
-      throw new Error(
-        `Must pass a string to this method. You passed an object! Keys: ${Object.keys(value)}`,
-      );
-    } else {
-      throw new Error(
-        `Must pass a string to this method. You passed ${value} which is type of: ${typeof value}`,
-      );
-    }
+    throw new Error(
+      `Must pass a string to this method. You passed ${value} which is type of: ${typeof value}`,
+    );
   }
 
   // #FFF (smallest possible hex color pattern)


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
~Sometimes Storybook fails on prod, but I don't understand why. This PR simplifies a utility method while expanding on the error message to have better insight when the issue occurs.~

This issue resolves a problem which caused Storybook to break in prod intermittently when the postcss plugin for exporting CSS variables met a race condition which passed an empty file to our style utilities.
