### PR TITLE
Use provider when mocking emails

### DIFF
--- a/test-utils/mockGenerators/mockUser.js
+++ b/test-utils/mockGenerators/mockUser.js
@@ -9,7 +9,10 @@ import mockPassword from './mockPassword';
  * @returns {Object.<string, string>}
  */
 export default function mockUser(desiredEmail = '') {
-  const email = desiredEmail || faker.internet.email();
+  const firstName = faker.name.firstName();
+  const lastName = faker.name.lastName();
+
+  const email = desiredEmail || faker.internet.email(firstName, lastName, 'operationcode.org');
   const password = mockPassword();
 
   const user = {
@@ -17,8 +20,8 @@ export default function mockUser(desiredEmail = '') {
     'confirm-email': email,
     password,
     'confirm-password': password,
-    firstName: faker.name.firstName(),
-    lastName: faker.name.lastName(),
+    firstName,
+    lastName,
     zipcode: faker.address.zipCode(),
   };
 


### PR DESCRIPTION
# Description of changes
We use faker to mock emails in our e2e tests. Those e2e tests run often and actually hit our back-end (leading to real emails). We don't want to accidentally email real people, so this PR prevents that.
