### PR TITLE
Pass array of Components instead of objects to steps prop

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -128,6 +128,8 @@
           "requiredProps": true,
           "defaultProps": true,
           "mapStateToProps": true,
+          "propValue": true,
+          "propFullName": true,
           "ctx": true
         }
       }

--- a/common/constants/custom-props.js
+++ b/common/constants/custom-props.js
@@ -40,3 +40,20 @@ export const googleAnalyticsEventStoryObjectFactory = () => ({
   nonInteraction: false,
   transport: undefined,
 });
+
+export function validStep(propValue, key, componentName, location, propFullName) {
+  if (!Object.getOwnPropertyNames(propValue[key]).includes('validationSchema')) {
+    return new Error(
+      `${propFullName} does not have a validateSchema function.  
+      All form steps must contain both validateSchema and submitHandler functions`,
+    );
+  }
+
+  if (!Object.getOwnPropertyNames(propValue[key]).includes('submitHandler')) {
+    return new Error(
+      `${propFullName} does not have a submitHandler function.  
+      All form steps must contain both validateSchema and submitHandler functions`,
+    );
+  }
+  return null;
+}

--- a/components/Form/MultiStepForm.js
+++ b/components/Form/MultiStepForm.js
@@ -9,6 +9,23 @@ import Form from 'components/Form/Form';
 import Alert from 'components/Alert/Alert';
 import styles from './MultiStepForm.css';
 
+function validStep(propValue, key, componentName, location, propFullName) {
+  if (!Object.getOwnPropertyNames(propValue[key]).includes('validationSchema')) {
+    return new Error(
+      `${propFullName} does not have a validateSchema function.  
+      All form steps must contain both validateSchema and submitHandler functions`,
+    );
+  }
+
+  if (!Object.getOwnPropertyNames(propValue[key]).includes('submitHandler')) {
+    return new Error(
+      `${propFullName} does not have a submitHandler function.  
+      All form steps must contain both validateSchema and submitHandler functions`,
+    );
+  }
+  return null;
+}
+
 class MultiStepForm extends React.Component {
   static propTypes = {
     // initialValues must be object where entire form's shape is described
@@ -16,13 +33,7 @@ class MultiStepForm extends React.Component {
 
     onFinalSubmit: PropTypes.func.isRequired,
     onFinalSubmitSuccess: PropTypes.func.isRequired,
-    steps: PropTypes.arrayOf(
-      PropTypes.shape({
-        render: PropTypes.func.isRequired,
-        validationSchema: PropTypes.object.isRequired, // specifically a Yup object shape
-        submitHandler: PropTypes.func.isRequired,
-      }),
-    ).isRequired,
+    steps: PropTypes.arrayOf(validStep).isRequired,
   };
 
   state = {
@@ -112,17 +123,17 @@ class MultiStepForm extends React.Component {
     const { initialValues, steps } = this.props;
     const { errorMessage, stepNumber } = this.state;
 
-    const currentStep = steps[stepNumber];
+    const CurrentStep = steps[stepNumber];
     const isFirstStep = stepNumber === 0;
 
     return (
       <Formik
         initialValues={initialValues}
-        validationSchema={currentStep.validationSchema}
+        validationSchema={CurrentStep.validationSchema}
         onSubmit={this.handleSubmit}
         render={formikBag => (
           <Form className={styles.MultiStepForm} onSubmit={formikBag.handleSubmit}>
-            {currentStep.render(formikBag)}
+            <CurrentStep {...formikBag} />
 
             <div className={styles.errorMessage}>
               <Alert isOpen={Boolean(errorMessage)} type="error">

--- a/components/Form/MultiStepForm.js
+++ b/components/Form/MultiStepForm.js
@@ -3,28 +3,12 @@ import PropTypes from 'prop-types';
 import get from 'lodash/get';
 import { Formik } from 'formik';
 import { getErrorMessage } from 'common/utils/api-utils';
+import { validStep } from 'common/constants/custom-props';
 import { capitalizeFirstLetter } from 'common/utils/string-utils';
 import Button from 'components/Button/Button';
 import Form from 'components/Form/Form';
 import Alert from 'components/Alert/Alert';
 import styles from './MultiStepForm.css';
-
-function validStep(propValue, key, componentName, location, propFullName) {
-  if (!Object.getOwnPropertyNames(propValue[key]).includes('validationSchema')) {
-    return new Error(
-      `${propFullName} does not have a validateSchema function.  
-      All form steps must contain both validateSchema and submitHandler functions`,
-    );
-  }
-
-  if (!Object.getOwnPropertyNames(propValue[key]).includes('submitHandler')) {
-    return new Error(
-      `${propFullName} does not have a submitHandler function.  
-      All form steps must contain both validateSchema and submitHandler functions`,
-    );
-  }
-  return null;
-}
 
 class MultiStepForm extends React.Component {
   static propTypes = {

--- a/components/Form/__tests__/MultiStepForm.test.js
+++ b/components/Form/__tests__/MultiStepForm.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp */
 import React from 'react';
 import faker from 'faker';
 import { mount } from 'enzyme';
@@ -19,87 +20,109 @@ const typeIntoInput = async (enzymeWrapper, inputName, value) => {
   input.simulate('change', { target: { id: inputName, value } }).simulate('blur');
 };
 
+function makeNameForm(submitHandler = jest.fn()) {
+  return class NameForm extends React.Component {
+    static validationSchema = Yup.object().shape({
+      firstName: Yup.string().required(),
+      lastName: Yup.string().required(),
+    });
+
+    static submitHandler = submitHandler;
+
+    render() {
+      const { props } = this;
+      return (
+        <>
+          <Field
+            type="text"
+            name="firstName"
+            id="firstName"
+            label="First Name*"
+            component="input"
+            {...props}
+          />
+          <Field
+            type="text"
+            name="lastName"
+            id="lastName"
+            label="Last Name*"
+            component="input"
+            {...props}
+          />
+        </>
+      );
+    }
+  };
+}
+
 describe('MultiStepForm', () => {
   // Define some mock form steps
   const nameFormSubmitHandler = jest.fn();
-  const NameForm = {
-    render: props => (
-      <>
-        <Field
-          type="text"
-          name="firstName"
-          id="firstName"
-          label="First Name*"
-          component="input"
-          {...props}
-        />
-        <Field
-          type="text"
-          name="lastName"
-          id="lastName"
-          label="Last Name*"
-          component="input"
-          {...props}
-        />
-      </>
-    ),
-    validationSchema: Yup.object().shape({
-      firstName: Yup.string().required(),
-      lastName: Yup.string().required(),
-    }),
-    submitHandler: nameFormSubmitHandler,
-  };
+
+  const NameForm = makeNameForm(nameFormSubmitHandler);
 
   const ultimateAnswerIncorrectMessage =
     'The Answer to the Ultimate Question of Life, the Universe, and Everything is 42';
   const ultimateAnswerFormSubmitHandler = jest.fn();
-  const UltimateAnswerForm = {
-    render: props => (
-      <Field
-        type="text"
-        name="ultimateAnswer"
-        id="ultimateAnswer"
-        label="What is the answer to the Ultimate Question of Life?*"
-        component="input"
-        {...props}
-      />
-    ),
-    validationSchema: Yup.object().shape({
+
+  class UltimateAnswerForm extends React.Component {
+    static validationSchema = Yup.object().shape({
       ultimateAnswer: Yup.string()
         .matches(/42/, ultimateAnswerIncorrectMessage)
         .required(),
-    }),
-    submitHandler: ultimateAnswerFormSubmitHandler,
-  };
+    });
+
+    static submitHandler = ultimateAnswerFormSubmitHandler;
+
+    render() {
+      const { props } = this;
+      return (
+        <Field
+          type="text"
+          name="ultimateAnswer"
+          id="ultimateAnswer"
+          label="What is the answer to the Ultimate Question of Life?*"
+          component="input"
+          {...props}
+        />
+      );
+    }
+  }
 
   const favoritesFormSubmitHandler = jest.fn();
-  const FavoritesForm = {
-    render: props => (
-      <>
-        <Field
-          type="text"
-          name="favoriteNumber"
-          id="favoriteNumber"
-          label="Favorite Number*"
-          component="input"
-          {...props}
-        />
-        <Field
-          type="text"
-          name="favoritePerson"
-          id="favoritePerson"
-          label="Favorite Person*"
-          component="input"
-          {...props}
-        />
-      </>
-    ),
-    validationSchema: Yup.object().shape({
+
+  class FavoritesForm extends React.Component {
+    static validationSchema = Yup.object().shape({
       favoriteNumber: Yup.string().required(),
       favoritePerson: Yup.string(),
-    }),
-    submitHandler: favoritesFormSubmitHandler,
-  };
+    });
+
+    static submitHandler = favoritesFormSubmitHandler;
+
+    render() {
+      const { props } = this;
+      return (
+        <>
+          <Field
+            type="text"
+            name="favoriteNumber"
+            id="favoriteNumber"
+            label="Favorite Number*"
+            component="input"
+            {...props}
+          />
+          <Field
+            type="text"
+            name="favoritePerson"
+            id="favoritePerson"
+            label="Favorite Person*"
+            component="input"
+            {...props}
+          />
+        </>
+      );
+    }
+  }
 
   const requiredProps = {
     initialValues: {
@@ -307,10 +330,8 @@ describe('MultiStepForm', () => {
 
   it('should handle error if custom handler throws after submitting', async () => {
     const mockedSubmitHandler = jest.fn().mockRejectedValueOnce(new Error());
-    const steps = [
-      { ...NameForm, submitHandler: mockedSubmitHandler },
-      { ...requiredProps.steps[1] },
-    ];
+
+    const steps = [makeNameForm(mockedSubmitHandler), requiredProps.steps[1]];
 
     const wrapper = mount(<MultiStepForm {...requiredProps} steps={steps} />);
 
@@ -329,10 +350,7 @@ describe('MultiStepForm', () => {
       .fn()
       .mockRejectedValue({ response: { data: { error: errorMessage } } });
 
-    const steps = [
-      { ...NameForm, submitHandler: mockedSubmitHandler },
-      { ...requiredProps.steps[1] },
-    ];
+    const steps = [makeNameForm(mockedSubmitHandler), requiredProps.steps[1]];
 
     const wrapper = mount(<MultiStepForm {...requiredProps} steps={steps} />);
 


### PR DESCRIPTION
# Description of changes
Refactors `MultiStepForm` to accept an array of Step Components as props instead of an array of objects.