### PR TITLE
Fixes #485

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "history": "^4.9.0",
     "js-cookie": "^2.2.0",
     "jwt-decode": "^2.2.0",
-    "lodash": "^4.17.11",
+    "lodash-es": "^4.17.11",
     "next": "^8.1.0",
     "next-cookies": "^1.1.2",
     "next-redux-wrapper": "^2.1.0",

--- a/pages/_app,mjs
+++ b/pages/_app,mjs
@@ -5,7 +5,7 @@ import { compose } from 'redux';
 import ScrollUpButton from 'react-scroll-up-button';
 import withRedux from 'next-redux-wrapper';
 import * as Sentry from '@sentry/browser';
-import debounce from 'lodash/debounce';
+import { debounce } from 'lodash-es';
 import { initStore } from 'store/store';
 import { screenResize } from 'store/screenSize/actions';
 import breakpoints from 'common/styles/breakpoints';


### PR DESCRIPTION
But `lodash-es` does not do named export `debounce`. So, I tried to import the complete `lodash-es` as a named export.