### PR TITLE
Add e2e tests for /profile/update

### DIFF
--- a/components/Form/MultiStepForm.js
+++ b/components/Form/MultiStepForm.js
@@ -132,6 +132,7 @@ export class MultiStepForm extends React.Component {
                   theme="secondary"
                   disabled={formikBag.isSubmitting}
                   onClick={() => this.showPreviousStep(formikBag)}
+                  data-testid="Previous Step Button"
                 >
                   {isMobileView ? (
                     <>
@@ -145,7 +146,12 @@ export class MultiStepForm extends React.Component {
               )}
 
               {this.isLastStep() ? (
-                <Button type="submit" theme="secondary" disabled={formikBag.isSubmitting}>
+                <Button
+                  type="submit"
+                  theme="secondary"
+                  disabled={formikBag.isSubmitting}
+                  data-testid="Submit Multi-Step Form"
+                >
                   Submit ✓
                 </Button>
               ) : (
@@ -154,6 +160,7 @@ export class MultiStepForm extends React.Component {
                   theme="secondary"
                   disabled={formikBag.isSubmitting}
                   fullWidth={isFirstStep}
+                  data-testid="Submit Step Button"
                 >
                   {isMobileView ? (
                     <>

--- a/components/Nav/Nav.js
+++ b/components/Nav/Nav.js
@@ -71,7 +71,7 @@ export class Nav extends Component {
     return (
       <header className={styles.header}>
         <div className={styles.navContainer}>
-          <nav className={styles.Nav}>
+          <nav className={styles.Nav} data-testid="Desktop Nav">
             <Link href="/">
               <a className={classNames(styles.logoLink, styles.link)}>
                 <img

--- a/components/Nav/__tests__/__snapshots__/Nav.test.js.snap
+++ b/components/Nav/__tests__/__snapshots__/Nav.test.js.snap
@@ -65,6 +65,7 @@ exports[`Nav should render with props passed 1`] = `
   >
     <nav
       className="Nav"
+      data-testid="Desktop Nav"
     >
       <Link
         href="/"

--- a/components/UpdateProfileForm/__tests__/__snapshots__/UpdateProfileForm.test.js.snap
+++ b/components/UpdateProfileForm/__tests__/__snapshots__/UpdateProfileForm.test.js.snap
@@ -203,6 +203,7 @@ exports[`UpdateProfileForm should render with required props 1`] = `
   >
     <button
       className="Button secondary fullWidth"
+      data-testid="Submit Step Button"
       disabled={false}
       onClick={[Function]}
       tabIndex={0}

--- a/components/UpdateProfileForm/steps/MilitaryStatus.js
+++ b/components/UpdateProfileForm/steps/MilitaryStatus.js
@@ -43,6 +43,7 @@ class MilitaryStatus extends React.Component {
             name="militaryStatus"
             label="Military Status*"
             component={Select}
+            instanceId="militaryStatus"
             options={[
               {
                 value: 'civilian',

--- a/cypress/integration/profile/update.spec.js
+++ b/cypress/integration/profile/update.spec.js
@@ -1,14 +1,104 @@
-describe('profile/update', () => {
+const goToNextStep = stepName => {
+  cy.get('button[data-testid="Submit Step Button"]').click();
+  cy.wait('@patchUser');
+  cy.get('h2').should('have.text', stepName);
+};
+
+const goToPreviousStep = stepName => {
+  cy.get('button[data-testid="Previous Step Button"]').click();
+  cy.get('h2').should('have.text', stepName);
+};
+
+const firstStepName = 'Professional Details';
+const secondStepName = 'Military Status';
+
+describe(`profile/update (unauthorized)`, () => {
+  it(`should redirect to login if not authorized`, () => {
+    // assert that route can't be reached without being authorized
+    cy.visit('/profile/update');
+    cy.get('nav[data-testid="Desktop Nav"]').should('exist');
+    cy.url().should('contain', '/login');
+    cy.url().should('not.contain', '/profile/update');
+    cy.get('h1').should('have.text', 'Login'); // redirect confirmed
+  });
+});
+
+describe(`profile/update (from login)`, () => {
   beforeEach(() => {
     cy.server();
     cy.login();
-    cy.route('PATCH', 'auth/profile').as('patchUser');
+    cy.route('PATCH', 'auth/profile/').as('patchUser');
 
     cy.visitAndWaitFor('/profile/update');
     cy.get('h1').should('have.text', 'Update Profile');
+    cy.get('h2').should('have.text', firstStepName);
   });
 
-  it(`should show up after login`, () => {
-    cy.get('h2').should('have.text', 'Professional Details');
+  after(() => cy.clearCookies());
+
+  it(`should route to profile after completing entire profile update (happy path)`, () => {
+    goToNextStep(secondStepName);
+    goToNextStep('Military Details');
+    goToNextStep('Technology');
+    cy.get('button[data-testid="Submit Multi-Step Form"]').click();
+    cy.wait('@patchUser');
+    cy.url().should('contain', '/profile');
+    cy.url().should('not.contain', '/profile/update');
+  });
+
+  it(`should see initial values populated when going to profile update from login`, () => {
+    cy.get('input[name="employmentStatus"]').should('have.value', 'fulltime');
+    cy.get('input[name="companyName"]').should('have.value', 'Googles');
+    cy.get('input[name="companyRole"]').should('have.value', 'CEO');
+
+    goToNextStep(secondStepName);
+
+    cy.get('input[name="militaryStatus"]').should('have.value', 'veteran');
+
+    goToNextStep('Military Details');
+
+    cy.get('input[name="branchOfService"]').should('have.value', 'army');
+    cy.get('input[name="yearsOfService"]').should('have.value', '3');
+    cy.get('input[name="payGrade"]').should('have.value', 'E20');
+
+    goToNextStep('Technology');
+
+    cy.get('input[name="programmingLanguages"]').should('have.value', '');
+    cy.get('input[name="disciplines"]').should('have.value', '');
+  });
+
+  it(`should be able to navigate back and forth`, () => {
+    goToNextStep(secondStepName);
+
+    goToPreviousStep(firstStepName);
+  });
+
+  it(`should not allow step submissions if cookie becomes invalid during some step`, () => {
+    goToNextStep(secondStepName);
+
+    cy.clearCookies();
+
+    cy.get('button[data-testid="Submit Step Button"]').click();
+    cy.get('div[role="alert"]').should('have.text', 'Request failed with status code 401');
+    cy.get('h2').should('have.text', secondStepName);
+  });
+
+  it(`should not show military step if military status is non-military`, () => {
+    goToNextStep(secondStepName);
+
+    cy.get('input#react-select-militaryStatus-input')
+      .type('Not Applicable', { force: true })
+      .type('{enter}');
+
+    // confirms that the next step is NOT military details
+    goToNextStep('Technology');
+    goToPreviousStep('Military Status');
+
+    cy.get('input#react-select-militaryStatus-input')
+      .type('Veteran', { force: true })
+      .type('{enter}');
+
+    // confirms that next step IS military details
+    goToNextStep('Military Details');
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -18,7 +18,7 @@ import { userInfoCookieNames } from '../../common/utils/cookie-utils';
 
 Cypress.Commands.add('visitAndWaitFor', path => {
   cy.visit(path);
-  cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
+  cy.get('nav[data-testid="Desktop Nav"]').should('exist');
   cy.url().should('contain', path);
 });
 


### PR DESCRIPTION
# Description of changes
- Speed up `cy.visitAndWaitFor()`
- Add some selectors / data-testids
- Add a bunch of Cypress tests for `/profile/update`

TODO:
- Add custom `cy.register()` command to imperatively create a user
- Create `(from registration)` suite in `/profile/update` e2e tests
- Test in that suite for happy path and against trying to skip required fields