### PR TITLE
Add nav link to user Profile page

### DIFF
--- a/common/constants/navigation.js
+++ b/common/constants/navigation.js
@@ -70,6 +70,12 @@ const getInvolved = {
   ],
 };
 
+const profile = {
+  name: 'Profile',
+  href: '/profile',
+  shouldPrefetch: false,
+};
+
 const logout = {
   name: 'Logout',
   href: '/login?loggedOut=true',
@@ -77,12 +83,19 @@ const logout = {
 };
 
 // MARK: Nav items
-export const loggedInNavItems = [aboutUs, whoWeServeWithoutSublinks, events, getInvolved, logout];
+export const loggedInNavItems = [
+  aboutUs,
+  whoWeServeWithoutSublinks,
+  events,
+  getInvolved,
+  profile,
+  logout,
+];
 export const loggedOutNavItems = [aboutUs, whoWeServeWithSublinks, events, getInvolved];
 
 // Extracts sublinks to list everything as a single, top-level list
 export const mobileLoggedInNavItems = flattenDepth(
-  [logout, aboutUs, whoWeServeWithoutSublinks, events, getInvolved].map(
+  [logout, profile, aboutUs, whoWeServeWithoutSublinks, events, getInvolved].map(
     ({ sublinks = [], ...item }) => [item, sublinks],
   ),
   2,


### PR DESCRIPTION
# Description of changes
Adds a link to the `/profile` page to the navbar.


# Issue Resolved
Currently there is no way for a user to return to their profile after navigating to a different page.

## Screenshots/GIFs
<!-- Please provide a view into the feature/bugfix if possible-->
Standard:
![image](https://user-images.githubusercontent.com/27715246/58887680-ac508b00-86ab-11e9-9851-c57cdd54e192.png)

Mobile:
![image](https://user-images.githubusercontent.com/27715246/58887694-b4a8c600-86ab-11e9-92fc-4530cd9f26e9.png)


