### PR TITLE
Simplify redux logic inside components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -202,6 +202,7 @@ module.exports = {
           getInitialProps: true,
           initialProps: true,
           mapStateToProps: true,
+          mapDispatchToProps: true,
           propFullName: true,
           propValue: true,
           props: true,

--- a/pages/join.js
+++ b/pages/join.js
@@ -14,7 +14,7 @@ const profileUpdateURL = '/profile/update';
 
 class Join extends React.Component {
   static propTypes = {
-    dispatch: func.isRequired,
+    dispatchLogin: func.isRequired,
     router: object.isRequired,
   };
 
@@ -25,10 +25,10 @@ class Join extends React.Component {
   }
 
   handleSuccess = ({ token, user }) => {
-    const { dispatch } = this.props;
+    const { dispatchLogin } = this.props;
 
     login({ token, user }, profileUpdateURL);
-    dispatch(setLoggedIn());
+    dispatchLogin();
   };
 
   render() {
@@ -57,6 +57,9 @@ class Join extends React.Component {
 }
 
 export default compose(
-  connect(),
+  connect(
+    null,
+    { dispatchLogin: setLoggedIn },
+  ),
   withRouter,
 )(Join);

--- a/pages/login.js
+++ b/pages/login.js
@@ -15,7 +15,9 @@ import SocialLoginGroup from 'components/SocialLoginGroup/SocialLoginGroup';
 
 class Login extends React.Component {
   static propTypes = {
-    dispatch: func.isRequired,
+    dispatchLogout: func.isRequired,
+    dispatchLogin: func.isRequired,
+    // pulled out of query param
     loggedOut: bool,
   };
 
@@ -37,19 +39,19 @@ class Login extends React.Component {
   }
 
   componentDidMount() {
-    const { dispatch, loggedOut } = this.props;
+    const { dispatchLogout, loggedOut } = this.props;
 
     // initiate logout if user was routed
     // here by clicking the logout link
     if (loggedOut) {
       logout({ shouldRedirect: false });
-      dispatch(setLoggedOut());
+      dispatchLogout();
     }
   }
 
   handleSuccess = ({ token, user }) => {
-    const { dispatch } = this.props;
-    dispatch(setLoggedIn());
+    const { dispatchLogin } = this.props;
+    dispatchLogin();
     login({ token, user });
   };
 
@@ -99,4 +101,11 @@ class Login extends React.Component {
   }
 }
 
-export default compose(connect())(Login);
+const mapStateToProps = ({ loggedIn }) => ({ loggedIn });
+
+export default compose(
+  connect(
+    mapStateToProps,
+    { dispatchLogin: setLoggedIn, dispatchLogout: setLoggedOut },
+  ),
+)(Login);

--- a/pages/login.js
+++ b/pages/login.js
@@ -17,6 +17,7 @@ class Login extends React.Component {
   static propTypes = {
     dispatchLogout: func.isRequired,
     dispatchLogin: func.isRequired,
+
     // pulled out of query param
     loggedOut: bool,
   };


### PR DESCRIPTION
# Description of changes
Leverages `connect`'s `mapDispatchToProps` to provide a single function that can be called by components needing to dispatch login/logout actions.

Also slightly increases performance by only passing the required props from the Redux store.