### PR TITLE
Various profile form bugfixes

### DIFF
--- a/components/Form/Input/Input.js
+++ b/components/Form/Input/Input.js
@@ -53,7 +53,7 @@ Input.defaultProps = {
 };
 
 function Input({
-  field: { name, ...field },
+  field: { name, value, ...field },
   form: { touched, errors },
   label,
   isLabelHidden,
@@ -85,6 +85,7 @@ function Input({
           id={id || name}
           name={name}
           type={type}
+          value={value || ''}
         />
 
         <ErrorMessage

--- a/components/Form/Input/__stories__/__snapshots__/Input.stories.storyshot
+++ b/components/Form/Input/__stories__/__snapshots__/Input.stories.storyshot
@@ -29,6 +29,7 @@ Array [
         id="someInput"
         name="someInput"
         type="text"
+        value=""
       />
     </div>
   </div>,

--- a/components/Form/Input/__tests__/__snapshots__/Input.test.js.snap
+++ b/components/Form/Input/__tests__/__snapshots__/Input.test.js.snap
@@ -18,6 +18,7 @@ exports[`Input should render with required props 1`] = `
       id="someInputName"
       name="someInputName"
       type="text"
+      value=""
     />
   </div>
 </div>

--- a/components/Form/Select/Select.js
+++ b/components/Form/Select/Select.js
@@ -20,7 +20,7 @@ class Select extends React.Component {
   static propTypes = {
     field: shape({
       name: string.isRequired,
-      value: oneOfType([string.isRequired, arrayOf(string.isRequired).isRequired]).isRequired,
+      value: oneOfType([string.isRequired, arrayOf(string.isRequired).isRequired]),
     }).isRequired,
     form: shape({
       // TODO: Resolve why multiselects can end up with touched: { key: array }
@@ -63,8 +63,11 @@ class Select extends React.Component {
    */
   onChangeMulti = selectedArray => {
     const { field, form } = this.props;
-
-    form.setFieldValue(field.name, selectedArray.map(item => item.value));
+    if (selectedArray) {
+      form.setFieldValue(field.name, selectedArray.map(item => item.value));
+    } else {
+      form.setFieldValue(field.name, []);
+    }
   };
 
   /**

--- a/components/Form/Select/__tests__/Select.test.js
+++ b/components/Form/Select/__tests__/Select.test.js
@@ -124,5 +124,29 @@ describe('Select', () => {
       expect(setFieldTouched).toHaveBeenCalledTimes(2);
       expect(setFieldValue).toHaveBeenCalledTimes(2);
     });
+
+    it('should be able to remove multiselect options', async () => {
+      const wrapper = mount(
+        <Select {...requiredProps} field={{ name: 'test', value: [] }} isMulti />,
+      );
+
+      const ReactSelect = getReactSelect(wrapper);
+
+      // down arrow once and enter
+      ReactSelect.simulate('blur');
+      ReactSelect.simulate('keyDown', { key: 'ArrowDown', keyCode: 40 });
+      await asyncRenderDiff(wrapper);
+      ReactSelect.simulate('keyDown', { key: 'Enter', keyCode: 13 });
+      await asyncRenderDiff(wrapper);
+
+      expect(setFieldValue).toHaveBeenCalledTimes(1);
+
+      // Remove single selected value
+      ReactSelect.simulate('keyDown', { key: 'Backspace', keyCode: 8 });
+
+      await asyncRenderDiff(wrapper);
+
+      expect(setFieldValue).toHaveBeenNthCalledWith(2, 'test', []);
+    });
   });
 });


### PR DESCRIPTION
# Description of changes
- Converts null values in input form elements to an empty string 
  - (the initial value is set as null when the form loads for the first time after a member joins)
- Adds null checking for multiselect for elements
  - Fixes bug that caused NPE to occur when removing the only selected element
- Adds regression test for multiselect null checking
