### PR TITLE
Limit the size of the login alert message to 500px or 100% width (whichever is smaller)

### DIFF
--- a/components/SocialLoginGroup/SocialLoginGroup.css
+++ b/components/SocialLoginGroup/SocialLoginGroup.css
@@ -45,6 +45,16 @@
   box-shadow: inset 0 0 0 32px rgba(0, 0, 0, 0.1);
 }
 
+/* Alert Message */
+.alertContainer {
+  margin-bottom: 1rem;
+}
+
+.alertFill {
+  max-width: 500px;
+  margin: 0 auto;
+}
+
 /* Facebook */
 .facebookButton {
   background-color: #4c69ba;

--- a/components/SocialLoginGroup/SocialLoginGroup.js
+++ b/components/SocialLoginGroup/SocialLoginGroup.js
@@ -41,13 +41,15 @@ class SocialLoginGroup extends React.Component {
 
     return (
       <div className={classNames(className, styles.flexRow, styles.SocialLoginGroup)}>
-        <Alert
-          className={classNames(styles.flexRow, styles.fullWidth)}
-          isOpen={Boolean(errorMessage)}
-          type="error"
-        >
-          {errorMessage}
-        </Alert>
+        <div className={classNames(styles.alertContainer, styles.fullWidth)}>
+          <Alert
+            className={classNames(styles.flexRow, styles.alertFill)}
+            isOpen={Boolean(errorMessage)}
+            type="error"
+          >
+            {errorMessage}
+          </Alert>
+        </div>
 
         {children({ onSuccess: this.onSuccess, onGoogleFailure: this.onGoogleFailure })}
       </div>

--- a/components/SocialLoginGroup/__tests__/__snapshots__/SocialLoginGroup.test.js.snap
+++ b/components/SocialLoginGroup/__tests__/__snapshots__/SocialLoginGroup.test.js.snap
@@ -5,10 +5,14 @@ exports[`SocialLoginGroup should render with required props 1`] = `
   className="flexRow SocialLoginGroup"
 >
   <div
-    className="Alert flexRow fullWidth error"
-    role="alert"
+    className="alertContainer fullWidth"
   >
-    
+    <div
+      className="Alert flexRow alertFill error"
+      role="alert"
+    >
+      
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
# Description of changes
I created an outer div container on the alert element so that I could maintain the 100% width property and control the size of the actual alert box separately. A margin-bottom: 1rem was also applied to the outer div container to create spacing between the alert and the social media buttons. This allowed me to do margin: 0 auto on the alert box itself.

# Issue Resolved
<!-- Keeping the format 'Fixes #{ISSUE_NUMBER}' will automatically close the issue when this PR is merged -->
Fixes #597

## Screenshots/GIFs
<!-- Please provide a view into the feature/bugfix if possible-->
![image](https://user-images.githubusercontent.com/34725510/59569382-9f358380-903d-11e9-9e4f-98905e56f339.png)

![image](https://user-images.githubusercontent.com/34725510/59569384-a8beeb80-903d-11e9-9607-a1efc8a6ea86.png)