### PR TITLE
limited years of service textbox to allow only numbers 1 to 40

### DIFF
--- a/components/UpdateProfileForm/steps/MilitaryDetails.js
+++ b/components/UpdateProfileForm/steps/MilitaryDetails.js
@@ -25,6 +25,7 @@ class MilitaryDetails extends React.Component {
     yearsOfService: Yup.number()
       .nullable()
       .positive('Enter a number between 1 and 40.')
+      .lessThan(41, 'Enter a number between 1 and 40.')
       .required(validationErrorMessages.required),
     payGrade: Yup.string()
       .nullable()

--- a/components/UpdateProfileForm/steps/MilitaryDetails.js
+++ b/components/UpdateProfileForm/steps/MilitaryDetails.js
@@ -24,6 +24,7 @@ class MilitaryDetails extends React.Component {
       .required(validationErrorMessages.required),
     yearsOfService: Yup.number()
       .nullable()
+      .positive('Enter a number between 1 and 40.')
       .required(validationErrorMessages.required),
     payGrade: Yup.string()
       .nullable()
@@ -86,6 +87,8 @@ class MilitaryDetails extends React.Component {
             label="Years Of Service*"
             component={Input}
             disabled={isSubmitting}
+            min="1"
+            max="40"
           />
 
           <Field

--- a/components/UpdateProfileForm/steps/__tests__/__snapshots__/MilitaryDetails.test.js.snap
+++ b/components/UpdateProfileForm/steps/__tests__/__snapshots__/MilitaryDetails.test.js.snap
@@ -154,6 +154,8 @@ exports[`UpdateProfileForm/Steps/MilitaryDetails should render in context of For
           className="Input"
           disabled={false}
           id="yearsOfService"
+          max="40"
+          min="1"
           name="yearsOfService"
           onBlur={[Function]}
           onChange={[Function]}

--- a/cypress/integration/profile/update.spec.js
+++ b/cypress/integration/profile/update.spec.js
@@ -58,7 +58,7 @@ describe(`profile/update (from login)`, () => {
     goToNextStep('Military Details');
 
     cy.get('input[name="branchOfService"]').should('have.value', 'army');
-    cy.get('input[name="yearsOfService"]').should('have.value', '31');
+    cy.get('input[name="yearsOfService"]').should('have.value', '3');
     cy.get('input[name="payGrade"]').should('have.value', 'E20');
 
     goToNextStep('Technology');
@@ -102,20 +102,29 @@ describe(`profile/update (from login)`, () => {
     goToNextStep('Military Details');
   });
 
-  it(`should not allow negative or greater values than 40 for years of service`, () => {
+  it(`should not allow negative in the years of service input`, () => {
     goToNextStep(secondStepName);
     goToNextStep(thirdStepName);
 
-    cy.get('input[name=yearsOfService]')
+    cy.get('input[name="yearsOfService"]')
       .clear()
       .type('-1');
+    
     cy.get('button[data-testid="Submit Step Button"]').click();
+    
     cy.get('div[role="alert"]').should('have.text', 'Enter a number between 1 and 40.');
+  });
+  
+  it(`should not allow numbers greater than 40 in the years of service input`, () => {
+    goToNextStep(secondStepName);
+    goToNextStep(thirdStepName);
 
-    cy.get('input[name=yearsOfService]')
+    cy.get('input[name="yearsOfService"]')
       .clear()
       .type('41');
+    
     cy.get('button[data-testid="Submit Step Button"]').click();
+    
     cy.get('div[role="alert"]').should('have.text', 'Enter a number between 1 and 40.');
   });
 });

--- a/cypress/integration/profile/update.spec.js
+++ b/cypress/integration/profile/update.spec.js
@@ -11,6 +11,7 @@ const goToPreviousStep = stepName => {
 
 const firstStepName = 'Professional Details';
 const secondStepName = 'Military Status';
+const thirdStepName = 'Military Details';
 
 describe(`profile/update (unauthorized)`, () => {
   it(`should redirect to login if not authorized`, () => {
@@ -57,7 +58,7 @@ describe(`profile/update (from login)`, () => {
     goToNextStep('Military Details');
 
     cy.get('input[name="branchOfService"]').should('have.value', 'army');
-    cy.get('input[name="yearsOfService"]').should('have.value', '3');
+    cy.get('input[name="yearsOfService"]').should('have.value', '31');
     cy.get('input[name="payGrade"]').should('have.value', 'E20');
 
     goToNextStep('Technology');
@@ -99,5 +100,22 @@ describe(`profile/update (from login)`, () => {
 
     // confirms that next step IS military details
     goToNextStep('Military Details');
+  });
+
+  it(`should not allow negative or greater values than 40 for years of service`, () => {
+    goToNextStep(secondStepName);
+    goToNextStep(thirdStepName);
+
+    cy.get('input[name=yearsOfService]')
+      .clear()
+      .type('-1');
+    cy.get('button[data-testid="Submit Step Button"]').click();
+    cy.get('div[role="alert"]').should('have.text', 'Enter a number between 1 and 40.');
+
+    cy.get('input[name=yearsOfService]')
+      .clear()
+      .type('41');
+    cy.get('button[data-testid="Submit Step Button"]').click();
+    cy.get('div[role="alert"]').should('have.text', 'Enter a number between 1 and 40.');
   });
 });


### PR DESCRIPTION
# Description of changes
I created limitations on the HTML and JS ends so that users can only save numbers between 1 and 40. On the HTML side, min and max values were added, but if users somehow bypass them through keyboard, JS limitations were included as well (i.e. Yup's .positive()).

# Issue Resolved
Fixes #611

## Screenshots/GIFs
![image](https://user-images.githubusercontent.com/34725510/59571830-8ccb4200-905d-11e9-809d-bc02bd4fdc41.png)