### PR TITLE
Add styling to board member headshots to maintain aspect ratio

### DIFF
--- a/pages/styles/team.css
+++ b/pages/styles/team.css
@@ -6,6 +6,10 @@
   width: 100%;
 }
 
+.boardMembers img {
+  object-fit: cover;
+}
+
 .foundingMembers {
   padding: 2rem 0 0 0;
 }


### PR DESCRIPTION
# Description of changes
Add styling to board member headshots to maintain aspect ratio

## Screenshots/GIFs
Before:
![image](https://user-images.githubusercontent.com/27715246/59951125-92e66780-943d-11e9-8783-9610252b1421.png)

After:
![image](https://user-images.githubusercontent.com/27715246/59951142-a1348380-943d-11e9-92c0-4f51ed0037c2.png)
