### PR TITLE
[#578] Remove target and rel attributes if mailto link for cross browser support

### DIFF
--- a/components/OutboundLink/OutboundLink.js
+++ b/components/OutboundLink/OutboundLink.js
@@ -20,12 +20,14 @@ OutboundLink.defaultProps = {
 };
 
 function OutboundLink({ analyticsEventLabel, children, className, hasIcon, href }) {
+  const isNotMailToLink = !href.startsWith('mailto:');
+
   return (
     <ReactGA.OutboundLink
       className={className}
       eventLabel={`OUTBOUND [${analyticsEventLabel}]`}
-      rel="noopener noreferrer"
-      target="_blank"
+      rel={isNotMailToLink && 'noopener noreferrer'}
+      target={isNotMailToLink && '_blank'}
       to={href}
     >
       <>

--- a/components/OutboundLink/OutboundLink.js
+++ b/components/OutboundLink/OutboundLink.js
@@ -26,8 +26,8 @@ function OutboundLink({ analyticsEventLabel, children, className, hasIcon, href 
     <ReactGA.OutboundLink
       className={className}
       eventLabel={`OUTBOUND [${analyticsEventLabel}]`}
-      rel={isNotMailToLink && 'noopener noreferrer'}
-      target={isNotMailToLink && '_blank'}
+      rel={isNotMailToLink ? 'noopener noreferrer' : undefined}
+      target={isNotMailToLink ? '_blank' : undefined}
       to={href}
     >
       <>


### PR DESCRIPTION
# Description of changes

If external link contains `mailto:` then strip the attributes `rel` and `target`, which on click were opening link in new tab. It's a bug in some browsers where it was opening a blank tab if user did not set their mail app up.

# Issue Resolved

Fixes #578 

## Screenshots/GIFs
<!-- Please provide a view into the feature/bugfix if possible-->
