### PR TITLE
Revert react-ga to 2.5.7 to fix trackerNames console error

### DIFF
--- a/components/FeaturedJobItem/__stories__/__snapshots__/FeaturedJobItem.stories.storyshot
+++ b/components/FeaturedJobItem/__stories__/__snapshots__/FeaturedJobItem.stories.storyshot
@@ -9,7 +9,6 @@ exports[`Storyshots FeaturedJobItem default 1`] = `
     onClick={[Function]}
     rel="noopener noreferrer"
     target="_blank"
-    trackerNames={null}
   >
     <span
       className="ScreenReaderOnly"

--- a/components/FeaturedJobItem/__tests__/__snapshots__/FeaturedJobItem.test.js.snap
+++ b/components/FeaturedJobItem/__tests__/__snapshots__/FeaturedJobItem.test.js.snap
@@ -9,7 +9,6 @@ exports[`FeaturedJobItem should render with many props assigned 1`] = `
     onClick={[Function]}
     rel="noopener noreferrer"
     target="_blank"
-    trackerNames={null}
   >
     <span
       className="ScreenReaderOnly"
@@ -92,7 +91,6 @@ exports[`FeaturedJobItem should render with required props 1`] = `
     onClick={[Function]}
     rel="noopener noreferrer"
     target="_blank"
-    trackerNames={null}
   >
     <span
       className="ScreenReaderOnly"

--- a/components/OutboundLink/__stories__/__snapshots__/OutboundLink.stories.storyshot
+++ b/components/OutboundLink/__stories__/__snapshots__/OutboundLink.stories.storyshot
@@ -6,7 +6,6 @@ exports[`Storyshots OutboundLink default 1`] = `
   onClick={[Function]}
   rel="noopener noreferrer"
   target="_blank"
-  trackerNames={null}
 >
   <span
     className="ScreenReaderOnly"

--- a/components/OutboundLink/__tests__/__snapshots__/OutboundLink.test.js.snap
+++ b/components/OutboundLink/__tests__/__snapshots__/OutboundLink.test.js.snap
@@ -6,7 +6,6 @@ exports[`OutboundLink should render with required props 1`] = `
   onClick={[Function]}
   rel="noopener noreferrer"
   target="_blank"
-  trackerNames={null}
 >
   <span
     className="ScreenReaderOnly"

--- a/components/PartnerLogoLink/__stories__/__snapshots__/PartnerLogoLink.stories.storyshot
+++ b/components/PartnerLogoLink/__stories__/__snapshots__/PartnerLogoLink.stories.storyshot
@@ -9,7 +9,6 @@ exports[`Storyshots PartnerLogoLink default 1`] = `
     onClick={[Function]}
     rel="noopener noreferrer"
     target="_blank"
-    trackerNames={null}
   >
     <span
       className="ScreenReaderOnly"

--- a/components/PartnerLogoLink/__tests__/__snapshots__/PartnerLogoLink.test.js.snap
+++ b/components/PartnerLogoLink/__tests__/__snapshots__/PartnerLogoLink.test.js.snap
@@ -9,7 +9,6 @@ exports[`PartnerLogoLink should render with required props 1`] = `
     onClick={[Function]}
     rel="noopener noreferrer"
     target="_blank"
-    trackerNames={null}
   >
     <span
       className="ScreenReaderOnly"

--- a/components/ReusableSections/JoinSection/__tests__/__snapshots__/JoinSection.test.js.snap
+++ b/components/ReusableSections/JoinSection/__tests__/__snapshots__/JoinSection.test.js.snap
@@ -32,7 +32,6 @@ exports[`JoinSection should render when not logged in 1`] = `
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
-      trackerNames={null}
     >
       <span
         className="ScreenReaderOnly"

--- a/components/ReusableSections/SponsorsSection/__tests__/__snapshots__/SponsorsSection.test.js.snap
+++ b/components/ReusableSections/SponsorsSection/__tests__/__snapshots__/SponsorsSection.test.js.snap
@@ -23,7 +23,6 @@ exports[`SponsorsSection should render with many props assigned 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -45,7 +44,6 @@ exports[`SponsorsSection should render with many props assigned 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -67,7 +65,6 @@ exports[`SponsorsSection should render with many props assigned 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -89,7 +86,6 @@ exports[`SponsorsSection should render with many props assigned 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -111,7 +107,6 @@ exports[`SponsorsSection should render with many props assigned 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -133,7 +128,6 @@ exports[`SponsorsSection should render with many props assigned 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -155,7 +149,6 @@ exports[`SponsorsSection should render with many props assigned 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -177,7 +170,6 @@ exports[`SponsorsSection should render with many props assigned 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -199,7 +191,6 @@ exports[`SponsorsSection should render with many props assigned 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -221,7 +212,6 @@ exports[`SponsorsSection should render with many props assigned 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -263,7 +253,6 @@ exports[`SponsorsSection should render with required props 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -285,7 +274,6 @@ exports[`SponsorsSection should render with required props 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -307,7 +295,6 @@ exports[`SponsorsSection should render with required props 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -329,7 +316,6 @@ exports[`SponsorsSection should render with required props 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -351,7 +337,6 @@ exports[`SponsorsSection should render with required props 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -373,7 +358,6 @@ exports[`SponsorsSection should render with required props 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -395,7 +379,6 @@ exports[`SponsorsSection should render with required props 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -417,7 +400,6 @@ exports[`SponsorsSection should render with required props 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -439,7 +421,6 @@ exports[`SponsorsSection should render with required props 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -461,7 +442,6 @@ exports[`SponsorsSection should render with required props 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"

--- a/components/ReusableSections/__stories__/__snapshots__/ReusableSections.stories.storyshot
+++ b/components/ReusableSections/__stories__/__snapshots__/ReusableSections.stories.storyshot
@@ -67,7 +67,6 @@ exports[`Storyshots ReusableSections JoinSection 1`] = `
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"
-      trackerNames={null}
     >
       <span
         className="ScreenReaderOnly"
@@ -106,7 +105,6 @@ exports[`Storyshots ReusableSections SponsorsSection 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -128,7 +126,6 @@ exports[`Storyshots ReusableSections SponsorsSection 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -150,7 +147,6 @@ exports[`Storyshots ReusableSections SponsorsSection 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -172,7 +168,6 @@ exports[`Storyshots ReusableSections SponsorsSection 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -194,7 +189,6 @@ exports[`Storyshots ReusableSections SponsorsSection 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -216,7 +210,6 @@ exports[`Storyshots ReusableSections SponsorsSection 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -238,7 +231,6 @@ exports[`Storyshots ReusableSections SponsorsSection 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -260,7 +252,6 @@ exports[`Storyshots ReusableSections SponsorsSection 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -282,7 +273,6 @@ exports[`Storyshots ReusableSections SponsorsSection 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"
@@ -304,7 +294,6 @@ exports[`Storyshots ReusableSections SponsorsSection 1`] = `
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
-          trackerNames={null}
         >
           <span
             className="ScreenReaderOnly"

--- a/components/SocialMedia/SocialMediaItem/__tests__/__snapshots__/SocialMediaItem.test.js.snap
+++ b/components/SocialMedia/SocialMediaItem/__tests__/__snapshots__/SocialMediaItem.test.js.snap
@@ -9,7 +9,6 @@ exports[`SocialMediaItem should render with required props 1`] = `
     onClick={[Function]}
     rel="noopener noreferrer"
     target="_blank"
-    trackerNames={null}
   >
     <span
       className="ScreenReaderOnly"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-facebook-login": "^4.1.1",
-    "react-ga": "^2.6.0",
+    "react-ga": "2.5.7",
     "react-google-login": "^5.0.4",
     "react-modal": "^3.8.1",
     "react-on-screen": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12133,10 +12133,10 @@ react-fuzzy@^0.5.2:
     fuse.js "^3.0.1"
     prop-types "^15.5.9"
 
-react-ga@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-2.6.0.tgz#c3fe830ead2ad25117e1d33280d9698de9b28496"
-  integrity sha512-GWHBWZDFjDGMkIk1LzroIn0mNTygKw3adXuqvGvheFZvlbpqMPbHsQsTdQBIxRRdXGQM/Zq+dQLRPKbwIHMTaw==
+react-ga@2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-2.5.7.tgz#1c80a289004bf84f84c26d46f3a6a6513081bf2e"
+  integrity sha512-UmATFaZpEQDO96KFjB5FRLcT6hFcwaxOmAJZnjrSiFN/msTqylq9G+z5Z8TYzN/dbamDTiWf92m6MnXXJkAivQ==
 
 react-google-login@^5.0.4:
   version "5.0.4"


### PR DESCRIPTION
# Description of changes
`react-ga` libraries latest update to 2.6.0 was causing browser console error from adding `trackerNames` to HTML attributes. Reverting back to 2.5.7 fixed error.

# Issue Resolved
<!-- Keeping the format 'Fixes #{ISSUE_NUMBER}' will automatically close the issue when this PR is merged -->
Fixes #625 

## Screenshots/GIFs
<!-- Please provide a view into the feature/bugfix if possible-->
