### PR TITLE
Remove podcast from featured links

### DIFF
--- a/common/constants/navigation.js
+++ b/common/constants/navigation.js
@@ -14,6 +14,12 @@ const faqLink = {
   shouldPrefetch: false,
 };
 
+const podcastLink = {
+  name: 'Podcast',
+  href: '/podcast',
+  shouldPrefetch: false,
+};
+
 const getInvolvedLink = {
   name: 'Get Involved',
   href: '/get_involved',
@@ -51,7 +57,7 @@ const aboutUs = {
   name: 'About Us',
   href: '/about',
   shouldPrefetch: true,
-  sublinks: [contactLink, faqLink],
+  sublinks: [contactLink, faqLink, podcastLink],
 };
 
 const events = {

--- a/components/Cards/FlatCard/FlatCard.css
+++ b/components/Cards/FlatCard/FlatCard.css
@@ -12,6 +12,7 @@
   width: 200px;
   position: absolute;
   top: -1rem;
+  object-fit: cover;
 }
 
 .rowCenter {

--- a/components/Cards/ImageCard/ImageCard.css
+++ b/components/Cards/ImageCard/ImageCard.css
@@ -9,6 +9,7 @@
 .image {
   height: 225px;
   width: 50%;
+  object-fit: cover;
 }
 
 .content {

--- a/components/Nav/__tests__/__snapshots__/Nav.test.js.snap
+++ b/components/Nav/__tests__/__snapshots__/Nav.test.js.snap
@@ -31,6 +31,11 @@ exports[`Nav should render with no props passed 1`] = `
           "shouldPrefetch": false,
         },
         Object {
+          "href": "/podcast",
+          "name": "Podcast",
+          "shouldPrefetch": false,
+        },
+        Object {
           "href": "/who_we_serve",
           "name": "Who We Serve",
           "shouldPrefetch": true,
@@ -96,6 +101,11 @@ exports[`Nav should render with no props passed 1`] = `
                 Object {
                   "href": "/faq",
                   "name": "FAQ",
+                  "shouldPrefetch": false,
+                },
+                Object {
+                  "href": "/podcast",
+                  "name": "Podcast",
                   "shouldPrefetch": false,
                 },
               ]

--- a/pages/about.js
+++ b/pages/about.js
@@ -120,6 +120,17 @@ export default () => (
             members of the military community.
           </p>
         </ImageCard>,
+        <ImageCard
+          alt="A pair of orange headphones resting on a laptop keyboard"
+          className={styles.imageCard}
+          imageSource={`${s3}headphones.jpg`}
+        >
+          <h6>Podcast</h6>
+          <p>
+            We have a podcast! You can listen into the amazing stories of our members. Visualize
+            your success through others&apos; footsteps.
+          </p>
+        </ImageCard>,
       ]}
     />
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -31,12 +31,6 @@ const featuredLinksArray = [
     imageSource: `${s3}redesign/images/meetup-lecture.jpg`,
     alt: 'Dozens of developers look at a lecturer.',
   },
-  {
-    href: 'podcast',
-    name: 'podcast',
-    imageSource: `${s3}redesign/images/fist-bumping.jpg`, // change photo
-    alt: 'A team fist-bumping eachother over a table.',
-  },
 ];
 
 const Home = () => (


### PR DESCRIPTION
# Description of changes
- Fixed issue where image ratios are funked in some places
- Remove podcast item from featured links on home page
- Add podcast as sublink for `About Us`
- Add item on about page detailing podcast's existence.