### PR TITLE
Turn off audio preload in podcast

### DIFF
--- a/pages/podcast.js
+++ b/pages/podcast.js
@@ -80,7 +80,19 @@ class Podcast extends React.Component {
 
                       <img src={image} alt={interviewee} className={styles.img} />
 
-                      <ReactPlayer url={source} controls width="80%" height="65px" />
+                      <ReactPlayer
+                        url={source}
+                        controls
+                        width="80%"
+                        height="65px"
+                        config={{
+                          file: {
+                            attributes: {
+                              preload: 'none',
+                            },
+                          },
+                        }}
+                      />
 
                       <p>{story}</p>
                     </Card>


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Set audio preload to none
# Issue Resolved
<!-- Keeping the format 'Fixes #{ISSUE_NUMBER}' will automatically close the issue when this PR is merged -->
Fixes #674 

## Screenshots/GIFs
<!-- Please provide a view into the feature/bugfix if possible-->
