### PR TITLE
Append trailing slash to /auth/user URL

### DIFF
--- a/common/constants/api.js
+++ b/common/constants/api.js
@@ -2,7 +2,7 @@ import { get, post, patch } from 'common/utils/api-utils';
 import { formatUserData } from 'common/utils/formatters';
 
 /* GET REQUESTS */
-export const getUserPromise = ({ token }) => get('auth/user', { token });
+export const getUserPromise = ({ token }) => get('auth/user/', { token });
 export const getCodeSchoolsPromise = () => get('api/v1/codeschools/');
 export const getTeamMembersPromise = () => get('api/v1/teamMembers/');
 


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Appends trailing slash to /auth/user url.  Current url responds with a redirect which apparently safari is too cool to follow.

# Issue Resolved
<!-- Keeping the format 'Fixes #{ISSUE_NUMBER}' will automatically close the issue when this PR is merged -->
Fixes #700 