### PR TITLE
Configure Jest for CI better

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -189,7 +189,7 @@ module.exports = {
   // unmockedModulePathPatterns: undefined,
 
   // Indicates whether each individual test should be reported during the run
-  verbose: true,
+  // verbose: false,
 
   // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
   // watchPathIgnorePatterns: [],

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "test:e2e:update-snaps": "cypress run --env updateSnapshots=true",
     "test:e2e:ci": "cypress run --record",
     "test": "cross-env NODE_ENV=test BABEL_ENV=test jest",
-    "test:ci": "yarn test --ci --coverage",
-    "test:changes": "yarn test --changedSince master",
-    "test:changes:watch": "yarn test --changedSince master --watch",
+    "test:ci": "yarn test --ci --coverage --verbose=false --silent=true",
+    "test:changes": "yarn test --changedSince master --verbose=true",
+    "test:changes:watch": "yarn test --changedSince master --watch --verbose=true",
     "test:watch": "yarn test --watch",
     "test:update-snaps": "yarn test -u"
   },


### PR DESCRIPTION
# Description of changes
It's difficult to spot issues even if you know to look at the CircleCI logs. This keeps current local development setup, but makes for a more ideal CI test log.