### PR TITLE
Unhide client tokens for my sanity

### DIFF
--- a/common/config/environment.js
+++ b/common/config/environment.js
@@ -1,11 +1,26 @@
+/*
+ * This file should only contain environment variables that are non-secret.
+ */
 const isProduction = process.env.NODE_ENV === 'production';
+
+// These are all exposed by the client, so there's no way to protect them anyways.
+export const clientTokens = isProduction
+  ? {
+      GOOGLE_ANALYTICS: 'UA-75642413-1',
+      LOGROCKET: 'uquzri',
+      OC_FACEBOOK_KEY: '207055783236912',
+      OC_GOOGLE_KEY: '448638408285-6ego1u9ic6qcbsiitr2m173pp1tbs27k.apps.googleusercontent.com',
+      SENTRY_DSN: 'https://90edfb8d1d9640cf86d8aefd57218d71@sentry.io/1443656',
+    }
+  : {
+      GOOGLE_ANALYTICS: '',
+      LOGROCKET: '',
+      OC_FACEBOOK_KEY: '399113557601038',
+      OC_GOOGLE_KEY: '973655216990-vvl9vfp9v13lfoq7ccm36e8ouukrgdfh.apps.googleusercontent.com',
+      SENTRY_DSN: '',
+    };
 
 // TODO: Use GH Actions to enable environment-based Now deploys and stop using prod on PR deploys
 export const apiUrl = isProduction
   ? 'https://api.operationcode.org'
   : 'https://api.staging.operationcode.org';
-
-export const facebookKey = process.env.OC_FACEBOOK_KEY || '399113557601038';
-export const googleKey =
-  process.env.OC_GOOGLE_KEY ||
-  '973655216990-vvl9vfp9v13lfoq7ccm36e8ouukrgdfh.apps.googleusercontent.com';

--- a/components/Modal/Modal.js
+++ b/components/Modal/Modal.js
@@ -31,7 +31,7 @@ function Modal({
   screenReaderLabel,
   shouldCloseOnOverlayClick,
 }) {
-  if (process.env.NODE_ENV === 'production' && process.env.GOOGLE_ANALYTICS_KEY) {
+  if (process.env.NODE_ENV === 'production') {
     ReactGA.modalview(screenReaderLabel);
   }
 

--- a/components/Modal/__tests__/Modal.test.js
+++ b/components/Modal/__tests__/Modal.test.js
@@ -32,7 +32,6 @@ describe('Modal', () => {
     ReactGA.initialize('foo', { testMode: true });
 
     process.env.NODE_ENV = 'production';
-    process.env.GOOGLE_ANALYTICS_KEY = 'debug';
 
     const props = {
       onRequestClose: () => {},

--- a/components/SocialLoginGroup/SocialLoginButtons.js
+++ b/components/SocialLoginGroup/SocialLoginButtons.js
@@ -3,7 +3,7 @@ import { func } from 'prop-types';
 import classNames from 'classnames';
 import GoogleLogin from 'react-google-login';
 import FacebookLogin from 'react-facebook-login/dist/facebook-login-render-props';
-import { facebookKey, googleKey } from 'common/config/environment';
+import { clientTokens } from 'common/config/environment';
 import styles from './SocialLoginGroup.css';
 
 SocialLoginButtons.propTypes = {
@@ -15,7 +15,7 @@ function SocialLoginButtons({ onSuccess, onGoogleFailure }) {
   return (
     <>
       <GoogleLogin
-        clientId={googleKey}
+        clientId={clientTokens.OC_GOOGLE_KEY}
         buttonText="Login"
         onSuccess={onSuccess('google')}
         onFailure={onGoogleFailure}
@@ -32,7 +32,7 @@ function SocialLoginButtons({ onSuccess, onGoogleFailure }) {
       />
 
       <FacebookLogin
-        appId={facebookKey}
+        appId={clientTokens.OC_FACEBOOK_KEY}
         callback={onSuccess('facebook')}
         redirectUri={typeof window === 'object' && `${window.location.origin}/login`}
         render={renderProps => (

--- a/next.config.js
+++ b/next.config.js
@@ -8,15 +8,6 @@ const nextConfig = withCSS({
   // see: https://zeit.co/guides/deploying-nextjs-with-now/
   target: 'serverless',
 
-  // eslint-disable-next-line unicorn/prevent-abbreviations
-  env: {
-    GOOGLE_ANALYTICS_TRACKING_ID: process.env.GOOGLE_ANALYTICS_TRACKING_ID,
-    LOGROCKET_KEY: process.env.LOGROCKET_KEY,
-    OC_FACEBOOK_KEY: process.env.OC_FACEBOOK_KEY,
-    OC_GOOGLE_KEY: process.env.OC_GOOGLE_KEY,
-    SENTRY_DSN: process.env.SENTRY_DSN,
-  },
-
   // NextCSS Config
   cssModules: true,
   cssLoaderOptions: {

--- a/now.json
+++ b/now.json
@@ -1,17 +1,8 @@
 {
   "version": 2,
   "name": "operation-code",
-  "alias": ["operation-code.now.sh"],
+  "alias": ["operation-code.now.sh", "www.operationcode.org", "operationcode.org"],
   "builds": [{ "src": "package.json", "use": "@now/next@canary" }],
-  "build": {
-    "env": {
-      "GOOGLE_ANALYTICS_TRACKING_ID": "@google-analytics-tracking-id",
-      "LOGROCKET_KEY": "@logrocket-key",
-      "OC_FACEBOOK_KEY": "@facebook-sso",
-      "OC_GOOGLE_KEY": "@google-sso",
-      "SENTRY_DSN": "@sentry-dsn"
-    }
-  },
   "routes": [
     {
       "src": "/_next/static/(?:[^/]+/pages|chunks|runtime|css|fonts)/.+",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -7,6 +7,7 @@ import ReactGA from 'react-ga';
 import ScrollUpButton from 'react-scroll-up-button';
 import setupLogRocketReact from 'logrocket-react';
 import * as Sentry from '@sentry/browser';
+import { clientTokens } from 'common/config/environment';
 import Nav from 'components/Nav/Nav';
 import Footer from 'components/Footer/Footer';
 import Modal from 'components/Modal/Modal';
@@ -48,10 +49,10 @@ class OperationCodeApp extends App {
   componentDidMount() {
     /* Analytics */
     // Temporary method until we do dynamic now configs
-    if (window.location.host.includes('operationcode.org') && isProduction) {
-      Sentry.init({ dsn: process.env.SENTRY_DSN, release: `front-end@${version}` });
-      LogRocket.init(`${process.env.LOGROCKET_KEY}/operation-code`);
-      ReactGA.initialize(process.env.GOOGLE_ANALYTICS_TRACKING_ID);
+    if (isProduction && window.location.host.includes('operationcode.org')) {
+      Sentry.init({ dsn: clientTokens.SENTRY_DSN, release: `front-end@${version}` });
+      LogRocket.init(`${clientTokens.LOGROCKET}/operation-code`);
+      ReactGA.initialize(clientTokens.GOOGLE_ANALYTICS);
 
       // Every crash report will have a LogRocket session URL.
       LogRocket.getSessionURL(sessionURL => {


### PR DESCRIPTION
# Description of changes
I want continuous deployment, but it's hard to get environment-based continuous deployment unless we use Now with GH Actions or embed a separate master-only Now CLI job in CircleCI config. Both methods are work to do and maintain, and it will still prevent automated deployments on a PR (I have to manually approve their deployments because secrets are in effect.

All that being said, every one of our "secret" tokens are exposed on the client and easily acquired, so what's the use in obfuscating their values?

YOLO