### PR TITLE
Fix for incorrect meta images on LinkedIn and Twitter

### DIFF
--- a/components/head.js
+++ b/components/head.js
@@ -17,7 +17,7 @@ Head.defaultProps = {
     // eslint-disable-next-line max-len
     'Operation Code is a 501(c)(3) non-profit dedicated to helping military members, veterans, and their families to learn how to get a job in the tech industry.',
   url: 'https://operationcode.org',
-  ogImage: `${s3}branding/logos/small-blue-logo.png`,
+  ogImage: `${s3}branding/oc_image.png`,
 };
 
 function Head({ children, title, description, url, ogImage }) {

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -26,6 +26,9 @@ export default class MyDocument extends Document {
           <link rel="icon" sizes="192x192" href="/static/apple-icon-180x180.png" />
           <link rel="apple-touch-icon" href="/static/apple-icon-180x180.png" />
           <meta name="twitter:card" content="summary_large_image" />
+          <meta name="twitter:image:alt" content="Operation Code Logo" />
+          <meta property="og:type" content="website" />
+          <meta property="og:image:alt" content="Operation Code Logo" />
           <meta property="og:image:width" content="1200" />
           <meta property="og:image:height" content="630" />
         </Head>


### PR DESCRIPTION
# Description of changes
This PR adds some meta tags in `pages/_document.js` to improve presentation on various social media platforms which uses the Open Graph Protocol. The default parameter `ogImage` in `components/head.js` is changed to use a more suitable image.

# Issue Resolved
Fixes #727 

## Screenshots/GIFs
### LinkedIn Post
![LinkedIn Post](https://user-images.githubusercontent.com/29674758/66003398-a638b280-e4c3-11e9-8968-8ff7987a8b9c.png)
### Twitter Card
![Twitter Card](https://user-images.githubusercontent.com/29674758/66003408-acc72a00-e4c3-11e9-8162-093951f1a89d.png)
