### PR TITLE
adds cypress command to clean up tests

### DIFF
--- a/cypress/integration/code_schools.spec.js
+++ b/cypress/integration/code_schools.spec.js
@@ -10,7 +10,7 @@ describe('code schools', () => {
 
     it('renders many code school cards', () => {
       // 40 is arbitrary, but it proves that the API is working and leading to rendered content
-      cy.dataTestId('SchoolCard').should('have.length.greaterThan', 30);
+      cy.findAllByTestId('SchoolCard').should('have.length.greaterThan', 30);
     });
 
     it('renders "Cincy Code IT Bootcamps" and "Tech Elevator" after filtering for Ohio', () => {
@@ -18,16 +18,16 @@ describe('code schools', () => {
         .type('Ohio', { force: true })
         .type('{enter}');
 
-      cy.dataTestId('SchoolCard Name: Cincy Code IT Bootcamps').should('exist');
-      cy.dataTestId('SchoolCard Name: Tech Elevator').should('exist');
+      cy.findByTestId('SchoolCard Name: Cincy Code IT Bootcamps').should('exist');
+      cy.findByTestId('SchoolCard Name: Tech Elevator').should('exist');
     });
 
     it('only renders relevant schools after clicking on "Schools Accepting GI Bill"', () => {
       cy.contains('Schools Accepting GI Bill').click();
 
-      cy.dataTestId('SchoolCard').each(card => {
+      cy.findAllByTestId('SchoolCard').each(card => {
         cy.wrap(card)
-          .dataTestId('GI Bill Ribbon')
+          .findAllByTestId('GI Bill Ribbon')
           .should('exist');
       });
     });
@@ -35,9 +35,9 @@ describe('code schools', () => {
     it('only renders code schools with an online option after clicking "Online Schools"', () => {
       cy.contains('Online Schools').click();
 
-      cy.dataTestId('SchoolCard').each(card => {
+      cy.findAllByTestId('SchoolCard').each(card => {
         cy.wrap(card)
-          .dataTestId('School has online')
+          .findAllByTestId('School has online')
           .should('exist');
       });
     });
@@ -47,7 +47,7 @@ describe('code schools', () => {
         .type('Alaska', { force: true })
         .type('{enter}');
 
-      cy.dataTestId('SchoolCard').should('have.length', 0);
+      cy.findByTestId('SchoolCard').should('have.length', 0);
     });
 
     it('renders no school cards after filtering for Alaska then all after selecting all', () => {
@@ -55,10 +55,10 @@ describe('code schools', () => {
         .type('Alaska', { force: true })
         .type('{enter}');
 
-      cy.dataTestId('SchoolCard').should('have.length', 0);
+      cy.findByTestId('SchoolCard').should('have.length', 0);
 
       cy.contains('All Schools').click();
-      cy.dataTestId('SchoolCard').should('have.length.greaterThan', 30);
+      cy.findAllByTestId('SchoolCard').should('have.length.greaterThan', 30);
     });
 
     it('renders all cards after un-filtering Alaska', () => {
@@ -67,7 +67,7 @@ describe('code schools', () => {
         .type('{enter}')
         .type('{backspace}');
 
-      cy.dataTestId('SchoolCard').should('have.length.greaterThan', 30);
+      cy.findAllByTestId('SchoolCard').should('have.length.greaterThan', 30);
     });
 
     it('should close when user clicks close button', () => {

--- a/cypress/integration/code_schools.spec.js
+++ b/cypress/integration/code_schools.spec.js
@@ -10,7 +10,7 @@ describe('code schools', () => {
 
     it('renders many code school cards', () => {
       // 40 is arbitrary, but it proves that the API is working and leading to rendered content
-      cy.get('[data-testid="SchoolCard"]').should('have.length.greaterThan', 30);
+      cy.dataTestId('SchoolCard').should('have.length.greaterThan', 30);
     });
 
     it('renders "Cincy Code IT Bootcamps" and "Tech Elevator" after filtering for Ohio', () => {
@@ -18,16 +18,16 @@ describe('code schools', () => {
         .type('Ohio', { force: true })
         .type('{enter}');
 
-      cy.get('[data-testid="SchoolCard Name: Cincy Code IT Bootcamps"]').should('exist');
-      cy.get('[data-testid="SchoolCard Name: Tech Elevator"]').should('exist');
+      cy.dataTestId('SchoolCard Name: Cincy Code IT Bootcamps').should('exist');
+      cy.dataTestId('SchoolCard Name: Tech Elevator').should('exist');
     });
 
     it('only renders relevant schools after clicking on "Schools Accepting GI Bill"', () => {
       cy.contains('Schools Accepting GI Bill').click();
 
-      cy.get('[data-testid="SchoolCard"]').each(card => {
+      cy.dataTestId('SchoolCard').each(card => {
         cy.wrap(card)
-          .find('[data-testid="GI Bill Ribbon"]')
+          .dataTestId('GI Bill Ribbon')
           .should('exist');
       });
     });
@@ -35,9 +35,9 @@ describe('code schools', () => {
     it('only renders code schools with an online option after clicking "Online Schools"', () => {
       cy.contains('Online Schools').click();
 
-      cy.get('[data-testid="SchoolCard"]').each(card => {
+      cy.dataTestId('SchoolCard').each(card => {
         cy.wrap(card)
-          .get('[data-testid="School has online"]')
+          .dataTestId('School has online')
           .should('exist');
       });
     });
@@ -47,7 +47,7 @@ describe('code schools', () => {
         .type('Alaska', { force: true })
         .type('{enter}');
 
-      cy.get('[data-testid="SchoolCard"]').should('have.length', 0);
+      cy.dataTestId('SchoolCard').should('have.length', 0);
     });
 
     it('renders no school cards after filtering for Alaska then all after selecting all', () => {
@@ -55,10 +55,10 @@ describe('code schools', () => {
         .type('Alaska', { force: true })
         .type('{enter}');
 
-      cy.get('[data-testid="SchoolCard"]').should('have.length', 0);
+      cy.dataTestId('SchoolCard').should('have.length', 0);
 
       cy.contains('All Schools').click();
-      cy.get('[data-testid="SchoolCard"]').should('have.length.greaterThan', 30);
+      cy.dataTestId('SchoolCard').should('have.length.greaterThan', 30);
     });
 
     it('renders all cards after un-filtering Alaska', () => {
@@ -67,7 +67,7 @@ describe('code schools', () => {
         .type('{enter}')
         .type('{backspace}');
 
-      cy.get('[data-testid="SchoolCard"]').should('have.length.greaterThan', 30);
+      cy.dataTestId('SchoolCard').should('have.length.greaterThan', 30);
     });
 
     it('should close when user clicks close button', () => {

--- a/cypress/integration/join.spec.js
+++ b/cypress/integration/join.spec.js
@@ -38,8 +38,8 @@ describe('join', () => {
       expect(cookies.some(({ value }) => value === newUser.zipcode)).to.be.true;
     });
 
-    cy.get('[data-testid="Nav Item Login"]').should('not.exist');
-    cy.get('[data-testid="Nav Item Logout"]').should('exist');
+    cy.dataTestId('Nav Item Login').should('not.exist');
+    cy.dataTestId('Nav Item Logout').should('exist');
   });
 
   it('should NOT be able to register with an existing email', () => {

--- a/cypress/integration/join.spec.js
+++ b/cypress/integration/join.spec.js
@@ -38,8 +38,8 @@ describe('join', () => {
       expect(cookies.some(({ value }) => value === newUser.zipcode)).to.be.true;
     });
 
-    cy.dataTestId('Nav Item Login').should('not.exist');
-    cy.dataTestId('Nav Item Logout').should('exist');
+    cy.findByTestId('Nav Item Login').should('not.exist');
+    cy.findByTestId('Nav Item Logout').should('exist');
   });
 
   it('should NOT be able to register with an existing email', () => {

--- a/cypress/integration/podcast.spec.js
+++ b/cypress/integration/podcast.spec.js
@@ -7,7 +7,7 @@ describe('podcast', () => {
     });
 
     it('renders many podcast cards', () => {
-      cy.dataTestId('Podcast Card').should('have.length.greaterThan', 0);
+      cy.findAllByTestId('Podcast Card').should('have.length.greaterThan', 0);
     });
   });
 

--- a/cypress/integration/podcast.spec.js
+++ b/cypress/integration/podcast.spec.js
@@ -7,7 +7,7 @@ describe('podcast', () => {
     });
 
     it('renders many podcast cards', () => {
-      cy.get('[data-testid="Podcast Card"]').should('have.length.greaterThan', 0);
+      cy.dataTestId('Podcast Card').should('have.length.greaterThan', 0);
     });
   });
 

--- a/cypress/integration/profile/update.spec.js
+++ b/cypress/integration/profile/update.spec.js
@@ -1,11 +1,11 @@
 const goToNextStep = stepName => {
-  cy.dataTestId('Submit Step Button').click();
+  cy.findByTestId('Submit Step Button').click();
   cy.wait('@patchUser');
   cy.get('h3').should('have.text', stepName);
 };
 
 const goToPreviousStep = stepName => {
-  cy.dataTestId('Previous Step Button').click();
+  cy.findByTestId('Previous Step Button').click();
   cy.get('h3').should('have.text', stepName);
 };
 
@@ -40,7 +40,7 @@ describe(`profile/update (from login)`, () => {
     goToNextStep(secondStepName);
     goToNextStep('Military Details');
     goToNextStep('Technology');
-    cy.dataTestId('Submit Multi-Step Form').click();
+    cy.findByTestId('Submit Multi-Step Form').click();
     cy.wait('@patchUser');
     cy.url().should('contain', '/profile');
     cy.url().should('not.contain', '/profile/update');
@@ -78,7 +78,7 @@ describe(`profile/update (from login)`, () => {
 
     cy.clearCookies();
 
-    cy.dataTestId('Submit Step Button').click();
+    cy.findByTestId('Submit Step Button').click();
     cy.get('div[role="alert"]').should('have.text', 'Request failed with status code 401');
     cy.get('h3').should('have.text', secondStepName);
   });
@@ -110,7 +110,7 @@ describe(`profile/update (from login)`, () => {
       .clear()
       .type('-1');
 
-    cy.dataTestId('Submit Step Button').click();
+    cy.findByTestId('Submit Step Button').click();
 
     cy.get('div[role="alert"]').should('have.text', 'Enter a number between 1 and 40.');
   });
@@ -123,7 +123,7 @@ describe(`profile/update (from login)`, () => {
       .clear()
       .type('41');
 
-    cy.dataTestId('Submit Step Button').click();
+    cy.findByTestId('Submit Step Button').click();
 
     cy.get('div[role="alert"]').should('have.text', 'Enter a number between 1 and 40.');
   });

--- a/cypress/integration/profile/update.spec.js
+++ b/cypress/integration/profile/update.spec.js
@@ -1,11 +1,11 @@
 const goToNextStep = stepName => {
-  cy.get('button[data-testid="Submit Step Button"]').click();
+  cy.dataTestId('Submit Step Button').click();
   cy.wait('@patchUser');
   cy.get('h3').should('have.text', stepName);
 };
 
 const goToPreviousStep = stepName => {
-  cy.get('button[data-testid="Previous Step Button"]').click();
+  cy.dataTestId('Previous Step Button').click();
   cy.get('h3').should('have.text', stepName);
 };
 
@@ -40,7 +40,7 @@ describe(`profile/update (from login)`, () => {
     goToNextStep(secondStepName);
     goToNextStep('Military Details');
     goToNextStep('Technology');
-    cy.get('button[data-testid="Submit Multi-Step Form"]').click();
+    cy.dataTestId('Submit Multi-Step Form').click();
     cy.wait('@patchUser');
     cy.url().should('contain', '/profile');
     cy.url().should('not.contain', '/profile/update');
@@ -78,7 +78,7 @@ describe(`profile/update (from login)`, () => {
 
     cy.clearCookies();
 
-    cy.get('button[data-testid="Submit Step Button"]').click();
+    cy.dataTestId('Submit Step Button').click();
     cy.get('div[role="alert"]').should('have.text', 'Request failed with status code 401');
     cy.get('h3').should('have.text', secondStepName);
   });
@@ -110,7 +110,7 @@ describe(`profile/update (from login)`, () => {
       .clear()
       .type('-1');
 
-    cy.get('button[data-testid="Submit Step Button"]').click();
+    cy.dataTestId('Submit Step Button').click();
 
     cy.get('div[role="alert"]').should('have.text', 'Enter a number between 1 and 40.');
   });
@@ -123,7 +123,7 @@ describe(`profile/update (from login)`, () => {
       .clear()
       .type('41');
 
-    cy.get('button[data-testid="Submit Step Button"]').click();
+    cy.dataTestId('Submit Step Button').click();
 
     cy.get('div[role="alert"]').should('have.text', 'Enter a number between 1 and 40.');
   });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -52,6 +52,13 @@ Cypress.Commands.add('setResolution', size => {
   }
 });
 
+// ***********************************************
+// Find an element by its "data-testod" attribute
+// ***********************************************
+Cypress.Commands.add('dataTestId', id => {
+  return cy.get(`[data-testid="${id}"]`);
+});
+
 //
 // -- This is a child command --
 // Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -18,8 +18,8 @@ import { userInfoCookieNames } from '../../common/utils/cookie-utils';
 
 Cypress.Commands.add('visitAndWaitFor', path => {
   cy.visit(path);
-  cy.get('[data-testid="Desktop Nav"]').should('exist');
-  cy.get('[data-testid="Desktop Nav"]').should('be.visible');
+  cy.dataTestId('Desktop Nav').should('exist');
+  cy.dataTestId('Desktop Nav').should('be.visible');
   cy.url().should('contain', path);
 });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -11,6 +11,7 @@
 //
 // -- This is a parent command --
 // Cypress.Commands.add("login", (email, password) => { ... })
+import '@testing-library/cypress/add-commands';
 import { addMatchImageSnapshotCommand } from 'cypress-image-snapshot/command';
 import existingUser from '../../test-utils/mocks/existingUser';
 import { apiUrl } from '../../common/config/environment';
@@ -18,8 +19,8 @@ import { userInfoCookieNames } from '../../common/utils/cookie-utils';
 
 Cypress.Commands.add('visitAndWaitFor', path => {
   cy.visit(path);
-  cy.dataTestId('Desktop Nav').should('exist');
-  cy.dataTestId('Desktop Nav').should('be.visible');
+  cy.findByTestId('Desktop Nav').should('exist');
+  cy.findByTestId('Desktop Nav').should('be.visible');
   cy.url().should('contain', path);
 });
 
@@ -50,13 +51,6 @@ Cypress.Commands.add('setResolution', size => {
   } else {
     cy.viewport(size);
   }
-});
-
-// ***********************************************
-// Find an element by its "data-testid" attribute
-// ***********************************************
-Cypress.Commands.add('dataTestId', id => {
-  return cy.get(`[data-testid="${id}"]`);
 });
 
 //

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -53,7 +53,7 @@ Cypress.Commands.add('setResolution', size => {
 });
 
 // ***********************************************
-// Find an element by its "data-testod" attribute
+// Find an element by its "data-testid" attribute
 // ***********************************************
 Cypress.Commands.add('dataTestId', id => {
   return cy.get(`[data-testid="${id}"]`);

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@storybook/addon-viewport": "3.4.11",
     "@storybook/addons": "3.4.11",
     "@storybook/react": "3.4.11",
+    "@testing-library/cypress": "^5.0.1",
     "@zeit/next-bundle-analyzer": "^0.1.2",
     "@zeit/next-css": "^1.0.1",
     "@zeit/next-source-maps": "0.0.4-canary.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1670,6 +1670,27 @@
     react-split-pane "^0.1.77"
     react-treebeard "^2.1.0"
 
+"@testing-library/cypress@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/cypress/-/cypress-5.0.1.tgz#ca65d6c610e4173621380dc40c94cf849dd4c9c4"
+  integrity sha512-OuQRO4F1hrR/hQYUacFNFOIF//Xs4j3ufwZZ5vGokGSY7jMFlh08iwJoyLwIvutvWrnFqCZLZ02j8VKWtWkIvw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@testing-library/dom" "^6.0.0"
+    "@types/testing-library__cypress" "^5.0.0"
+
+"@testing-library/dom@^6.0.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.5.0.tgz#9419fec57a544917bd5e398d40826425be50ee0a"
+  integrity sha512-3lQx248dhJzvV2a76F1VaqehX+iquSVVW27caDaLoQZdUHEZjB370n7FO2WoYwOQQ7NB10AvfPhrARYnNgvf1g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    "@types/testing-library__dom" "^6.0.0"
+    aria-query "3.0.0"
+    pretty-format "^24.8.0"
+    wait-for-expect "^1.3.0"
+
 "@testing-library/dom@^6.3.0":
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.4.1.tgz#4efd38d896b9b2255025acf9567e2360e1f4814f"
@@ -1783,6 +1804,13 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/jquery@*":
+  version "3.3.31"
+  resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.3.31.tgz#27c706e4bf488474e1cb54a71d8303f37c93451b"
+  integrity sha512-Lz4BAJihoFw5nRzKvg4nawXPzutkv7wmfQ5121avptaSIXlDNJCUuxZxX/G+9EVidZGuO0UBlk+YjKbwRKJigg==
+  dependencies:
+    "@types/sizzle" "*"
+
 "@types/json-schema@^7.0.3":
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
@@ -1828,10 +1856,23 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/sizzle@*":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
+  integrity sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/testing-library__cypress@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__cypress/-/testing-library__cypress-5.0.0.tgz#23586b6183a504c59fbd716ba2bd2d5a909528e6"
+  integrity sha512-0tpxkL+9nJTtSCbdGYA6/rB3/2dRvH7QrFsR1sjuLlK5iU9BVSbjaiy1h0nhnh314U9rtvp8h2Vxz2Vh717+6w==
+  dependencies:
+    "@types/jquery" "*"
+    "@types/testing-library__dom" "*"
 
 "@types/testing-library__dom@*":
   version "6.0.0"


### PR DESCRIPTION
# Description of changes
Adds a cypress command to grab elements by `testid`. Gets rid of having to manually type out the `data-testid` css selector.

All specs still passing as expected
