### PR TITLE
Fix regressions with heading components

### DIFF
--- a/components/Content/__tests__/__snapshots__/Content.test.js.snap
+++ b/components/Content/__tests__/__snapshots__/Content.test.js.snap
@@ -16,6 +16,7 @@ exports[`Content should render with many props assigned 1`] = `
       >
         <div
           className="hashLinkContainer"
+          data-testid="Heading Content testing-link"
         >
           <a
             data-testid="Hash Link"

--- a/components/Heading/Heading.css
+++ b/components/Heading/Heading.css
@@ -20,8 +20,9 @@
 }
 
 @media screen and (--small-viewport) {
-  .hashLinkContainer {
-    width: min-content;
+  .hashLinkContainer a {
+    visibility: hidden;
+    display: none;
   }
 }
 

--- a/components/Heading/Heading.css
+++ b/components/Heading/Heading.css
@@ -19,13 +19,6 @@
   position: relative;
 }
 
-@media screen and (--small-viewport) {
-  .hashLinkContainer a {
-    visibility: hidden;
-    display: none;
-  }
-}
-
 .hashLinkContainer > a {
   position: absolute;
   left: -2rem;
@@ -39,15 +32,28 @@
   outline: none;
 }
 
+/* Hide on mobile always */
+@media screen and (--small-viewport) {
+  .hashLinkContainer a {
+    opacity: 0;
+    visibility: hidden;
+    display: none;
+  }
+}
+
 .Heading .icon {
+  display: none;
   opacity: 0;
   visibility: hidden;
   transition: 0.2s linear opacity, 0.2s linear visibility;
 }
 
-.Heading:hover .icon,
-.Heading a:focus .icon {
-  opacity: 1;
-  visibility: visible;
-  transition: 0.2s linear opacity, 0.2s linear visibility;
+@media not screen and (--small-viewport) {
+  .Heading:hover .icon,
+  .Heading a:focus .icon {
+    display: block;
+    opacity: 1;
+    visibility: visible;
+    transition: 0.2s linear opacity, 0.2s linear visibility;
+  }
 }

--- a/components/Heading/Heading.js
+++ b/components/Heading/Heading.js
@@ -33,7 +33,7 @@ function Heading({ className, hasHashLink, hasTitleUnderline, headingLevel, text
         })}
       >
         {hasHashLink ? (
-          <div className={styles.hashLinkContainer}>
+          <div className={styles.hashLinkContainer} data-testid={`Heading Content ${anchorId}`}>
             <a id={anchorId} href={`#${anchorId}`} data-testid="Hash Link">
               <ScreenReaderOnly>Scroll Link for {text}</ScreenReaderOnly>
               <LinkIcon className={styles.icon} />

--- a/components/Heading/__stories__/__snapshots__/Heading.stories.storyshot
+++ b/components/Heading/__stories__/__snapshots__/Heading.stories.storyshot
@@ -9,6 +9,7 @@ exports[`Storyshots Heading default 1`] = `
   >
     <div
       className="hashLinkContainer"
+      data-testid="Heading Content test-heading-link"
     >
       <a
         data-testid="Hash Link"

--- a/components/Heading/__tests__/__snapshots__/Heading.test.js.snap
+++ b/components/Heading/__tests__/__snapshots__/Heading.test.js.snap
@@ -21,6 +21,7 @@ exports[`Heading should render with required props 1`] = `
   >
     <div
       className="hashLinkContainer"
+      data-testid="Heading Content test-link"
     >
       <a
         data-testid="Hash Link"

--- a/components/ReusableSections/JoinSection/__tests__/__snapshots__/JoinSection.test.js.snap
+++ b/components/ReusableSections/JoinSection/__tests__/__snapshots__/JoinSection.test.js.snap
@@ -16,6 +16,7 @@ exports[`JoinSection should render when not logged in 1`] = `
       >
         <div
           className="hashLinkContainer"
+          data-testid="Heading Content join-our-thriving-community-link"
         >
           <a
             data-testid="Hash Link"

--- a/components/ReusableSections/SponsorsSection/__tests__/__snapshots__/SponsorsSection.test.js.snap
+++ b/components/ReusableSections/SponsorsSection/__tests__/__snapshots__/SponsorsSection.test.js.snap
@@ -15,6 +15,7 @@ exports[`SponsorsSection should render with many props assigned 1`] = `
       >
         <div
           className="hashLinkContainer"
+          data-testid="Heading Content sponsors-link"
         >
           <a
             data-testid="Hash Link"
@@ -366,6 +367,7 @@ exports[`SponsorsSection should render with required props 1`] = `
       >
         <div
           className="hashLinkContainer"
+          data-testid="Heading Content sponsors-link"
         >
           <a
             data-testid="Hash Link"

--- a/components/ReusableSections/__stories__/__snapshots__/ReusableSections.stories.storyshot
+++ b/components/ReusableSections/__stories__/__snapshots__/ReusableSections.stories.storyshot
@@ -20,6 +20,7 @@ exports[`Storyshots ReusableSections DonateSection 1`] = `
       >
         <div
           className="hashLinkContainer"
+          data-testid="Heading Content donate-link"
         >
           <a
             data-testid="Hash Link"
@@ -76,6 +77,7 @@ exports[`Storyshots ReusableSections JoinSection 1`] = `
       >
         <div
           className="hashLinkContainer"
+          data-testid="Heading Content join-our-thriving-community-link"
         >
           <a
             data-testid="Hash Link"
@@ -147,6 +149,7 @@ exports[`Storyshots ReusableSections SponsorsSection 1`] = `
       >
         <div
           className="hashLinkContainer"
+          data-testid="Heading Content sponsors-link"
         >
           <a
             data-testid="Hash Link"

--- a/cypress/integration/hashlink.spec.js
+++ b/cypress/integration/hashlink.spec.js
@@ -25,5 +25,18 @@ describe('Hash Links', () => {
         verifyHashLink(path);
       });
     });
+
+    describe('on small viewports', () => {
+      it('renders the anchors invisibly', () => {
+        cy.visitAndWaitFor(path);
+        cy.viewport('iphone-6');
+
+        cy.findAllByTestId('Hash Link').each(link => {
+          const { hash } = link[0];
+
+          cy.get(hash).should('not.be.visible');
+        });
+      });
+    });
   });
 });

--- a/cypress/integration/hashlink.spec.js
+++ b/cypress/integration/hashlink.spec.js
@@ -26,8 +26,27 @@ describe('Hash Links', () => {
       });
     });
 
+    // TODO: Uncomment when https://github.com/cypress-io/cypress/issues/10 is resolved
+    // describe('on large viewports', () => {
+    //   it('is invisible until hovered', () => {
+    //     cy.visitAndWaitFor(path);
+
+    //     cy.findAllByTestId('Hash Link').each(link => {
+    //       const { hash, id } = link[0];
+
+    //       cy.get(hash)
+    //         .scrollIntoView()
+    //         .should('not.be.visible');
+
+    //       cy.queryByTestId(`Heading Content ${id}`).hover()
+
+    //       cy.get(hash).should('be.visible');
+    //     });
+    //   });
+    // });
+
     describe('on small viewports', () => {
-      it('renders the anchors invisibly', () => {
+      it('is always invisible', () => {
         cy.visitAndWaitFor(path);
         cy.viewport('iphone-6');
 


### PR DESCRIPTION
# Description of changes
We'll just prevent seeing/clicking scroll links on mobile since there's not much real-estate to work with there and people aren't usually sharing in that manner.