### PR TITLE
update builders (component and test files)

### DIFF
--- a/scripts/createComponent/builders.js
+++ b/scripts/createComponent/builders.js
@@ -54,7 +54,7 @@ storiesOf('${componentName}', module)
   // Output generated for component's test file
   buildTestJs: componentName =>
     `import React from 'react';
-import { render, act } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import ${componentName} from '../${componentName}';
 

--- a/scripts/createComponent/builders.js
+++ b/scripts/createComponent/builders.js
@@ -3,23 +3,18 @@
 module.exports = {
   // Output generated for component's definition file
   buildJS: componentName =>
-    `import React, { useState, useEffect } from 'react';
-import { oneOfType, arrayOf, element, string, node, number } from 'prop-types';
+    `import React from 'react';
+import { string, node } from 'prop-types';
 import classNames from 'classnames';
 import styles from './${componentName}.css';
 
 ${componentName}.propTypes = {
-  children: oneOfType([
-    arrayOf(node),
-    element,
-    string,
-  ]),
+  children: node.isRequired,
   className: string,
 };
 
 ${componentName}.defaultProps = {
   className: undefined,
-  children: null,
 };
 
 export default function ${componentName}({ className, children }) {

--- a/scripts/createComponent/builders.js
+++ b/scripts/createComponent/builders.js
@@ -54,24 +54,11 @@ storiesOf('${componentName}', module)
   // Output generated for component's test file
   buildTestJs: componentName =>
     `import React from 'react';
-import createSnapshotTest from 'test-utils/createSnapshotTest';
 import { render, act } from '@testing-library/react';
 
 import ${componentName} from '../${componentName}';
 
 describe('${componentName}', () => {
-  it('should render with required props', () => {
-    createSnapshotTest(<${componentName}>Test</${componentName}>);
-  });
-
-  it('should render with many props assigned', () => {
-    createSnapshotTest(
-      <${componentName} className="test-class">
-        Test
-      </${componentName}>,
-    );
-  });
-
   it('should not render', () => {
     const { container } = render(<${componentName} />);
 

--- a/scripts/createComponent/builders.js
+++ b/scripts/createComponent/builders.js
@@ -54,10 +54,10 @@ import { render } from '@testing-library/react';
 import ${componentName} from '../${componentName}';
 
 describe('${componentName}', () => {
-  it('should not render', () => {
+  it('should render', () => {
     const { container } = render(<${componentName} />);
 
-    expect(container.firstChild).toBeNull();
+    expect(container.firstChild).not.toBeNull();
   })
 });
 `,

--- a/scripts/createComponent/builders.js
+++ b/scripts/createComponent/builders.js
@@ -3,30 +3,27 @@
 module.exports = {
   // Output generated for component's definition file
   buildJS: componentName =>
-    `import React from 'react';
-import { oneOfType, arrayOf, element, string, node } from 'prop-types';
+    `import React, { useState, useEffect } from 'react';
+import { oneOfType, arrayOf, element, string, node, number } from 'prop-types';
 import classNames from 'classnames';
 import styles from './${componentName}.css';
 
-export default class ${componentName} extends React.Component {
-  static propTypes = {
-    children: oneOfType([
-      arrayOf(node),
-      element,
-      string,
-    ]).isRequired,
-    className: string,
-  };
+${componentName}.propTypes = {
+  children: oneOfType([
+    arrayOf(node),
+    element,
+    string,
+  ]),
+  className: string,
+};
 
-  static defaultProps = {
-    className: undefined,
-  };
+${componentName}.defaultProps = {
+  className: undefined,
+  children: null,
+};
 
-  render() {
-    const { props } = this;
-
-    return <div className={classNames(props.className, styles.${componentName})}>{props.children}</div>;
-  }
+export default function ${componentName}({ className, children }) {
+  return <div className={classNames(className, styles.${componentName})}>{children}</div>
 }
 `,
 
@@ -58,6 +55,7 @@ storiesOf('${componentName}', module)
   buildTestJs: componentName =>
     `import React from 'react';
 import createSnapshotTest from 'test-utils/createSnapshotTest';
+import { render, act } from '@testing-library/react';
 
 import ${componentName} from '../${componentName}';
 
@@ -73,6 +71,12 @@ describe('${componentName}', () => {
       </${componentName}>,
     );
   });
+
+  it('should not render', () => {
+    const { container } = render(<${componentName} />);
+
+    expect(container.firstChild).toBeNull();
+  })
 });
 `,
 };


### PR DESCRIPTION
This PR updates the ` scripts/createComponent/builders.js` file to adhere to new standards.

- Test file references react-testing-library instead of enzime #850 
- Component file uses functional component style instead of classes. #845 
