### PR TITLE
Fix json typo

### DIFF
--- a/now.json
+++ b/now.json
@@ -7,7 +7,7 @@
     {
       "source": "/media",
       "destination": "/branding"
-    },
+    }
   ],
   "redirects": [
     {


### PR DESCRIPTION
The `now.json` file was not valid JSON. This PR removes the trailing comma to ensure `now.json` is valid JSON.