### PR TITLE
Minor fix to /resources page routing

### DIFF
--- a/now.json
+++ b/now.json
@@ -6,10 +6,6 @@
     {
       "source": "/media",
       "destination": "/branding"
-    },
-    {
-      "source": "/resources",
-      "destination": "/resources/1"
     }
   ],
   "redirects": [

--- a/pages/resources.js
+++ b/pages/resources.js
@@ -5,7 +5,7 @@ import HeroBanner from 'components/HeroBanner/HeroBanner';
 import ResourceCard from 'components/Cards/ResourceCard/ResourceCard';
 import Pagination from 'components/Pagination/Pagination';
 import { getResourcesPromise } from 'common/constants/api';
-import styles from '../styles/resources.module.css';
+import styles from './styles/resources.module.css';
 
 ResourcesPage.propTypes = {
   currentPage: PropTypes.number.isRequired,


### PR DESCRIPTION
# Description of changes
No documentation found for why /resources was in its own sub-directory. Moves /resources from sub-directory into /pages to better align with current page structure. 