### PR TITLE
temporarily update URLs, until SSL certificates can be fixed. this should fix prod

### DIFF
--- a/common/config/environment.js
+++ b/common/config/environment.js
@@ -22,5 +22,5 @@ export const clientTokens = isProduction
 
 // TODO: Use GH Actions to enable environment-based Now deploys and stop using prod on PR deploys
 export const apiUrl = isProduction
-  ? 'https://api.operationcode.org'
-  : 'https://api.staging.operationcode.org';
+  ? 'https://backend.k8s.operationcode.org'
+  : 'https://backend-staging.k8s.operationcode.org';

--- a/common/utils/api-utils.js
+++ b/common/utils/api-utils.js
@@ -14,7 +14,7 @@ export const OperationCodeAPI = axios.create(axiosConfig);
 // This API is also part of operation code, and documented here:
 // https://github.com/OperationCode/resources_api
 export const ResourcesAPI = axios.create({
-  baseURL: 'https://resources.operationcode.org',
+  baseURL: 'https://resources.k8s.operationcode.org',
   timeout: 5000,
 });
 export const ExternalAPI = axios.create({


### PR DESCRIPTION

Signed-off-by: Irving Popovetsky <irving@popovetsky.com>

# Description of changes
<!-- What does this PR change and why -->
The ACM-managed SSL certs on the new EKS cluster are for `*.k8s.operationcode.org` but not for `*.operationcode.org`, that's causing SSL failures 

# Issue Resolved
<!-- Keeping the format 'Fixes #{ISSUE_NUMBER}' will automatically close the issue when this PR is merged -->
Fixes #

## Screenshots/GIFs
<!-- Please provide a view into the feature/bugfix if possible-->
