### PR TITLE
ISSUE-1019: Dynamically updating OC member count on OC website

### DIFF
--- a/common/config/environment.js
+++ b/common/config/environment.js
@@ -25,7 +25,6 @@ export const apiUrl = isProduction
   ? 'https://backend.k8s.operationcode.org'
   : 'https://backend-staging.k8s.operationcode.org';
 
-export const slackApiUrl = 'https://slack.com/api';
+export const slackMembersAPIUrl = 'https://slack.com/api/conversations.members';
 // If running in production — Use OC-Actual Slack general channel
 export const slackGeneralChannelId = isProduction ? 'C03GSNF6X' : 'CURH72A9X';
-export const slackConversationsMembersEndpoint = '/conversations.members';

--- a/common/config/environment.js
+++ b/common/config/environment.js
@@ -26,6 +26,4 @@ export const apiUrl = isProduction
   : 'https://backend-staging.k8s.operationcode.org';
 
 export const slackMembersAPIUrl = 'https://slack.com/api/conversations.members';
-// If running in production — Use OC-Actual Slack general channel
 export const slackGeneralChannelId = 'C03GSNF6X';
-export const slackConversationsMembersEndpoint = '/conversations.members';

--- a/common/config/environment.js
+++ b/common/config/environment.js
@@ -24,3 +24,6 @@ export const clientTokens = isProduction
 export const apiUrl = isProduction
   ? 'https://backend.k8s.operationcode.org'
   : 'https://backend-staging.k8s.operationcode.org';
+
+export const slackApiUrl = 'https://slack.com/api';
+export const slackGeneralChannelId = isProduction ? '1234567890' : 'CURH72A9X';

--- a/common/config/environment.js
+++ b/common/config/environment.js
@@ -26,4 +26,6 @@ export const apiUrl = isProduction
   : 'https://backend-staging.k8s.operationcode.org';
 
 export const slackApiUrl = 'https://slack.com/api';
-export const slackGeneralChannelId = isProduction ? '1234567890' : 'CURH72A9X';
+// If running in production — Use OC-Actual Slack general channel
+export const slackGeneralChannelId = isProduction ? 'C03GSNF6X' : 'CURH72A9X';
+export const slackConversationsMembersEndpoint = '/conversations.members';

--- a/pages/who_we_serve.js
+++ b/pages/who_we_serve.js
@@ -13,7 +13,11 @@ import ScholarshipsIcon from 'static/images/icons/Custom/scholarships.svg';
 import { s3 } from 'common/constants/urls';
 import axios from 'axios';
 import PropTypes from 'prop-types';
-import { slackApiUrl, slackGeneralChannelId } from '../common/config/environment';
+import {
+  slackApiUrl,
+  slackGeneralChannelId,
+  slackConversationsMembersEndpoint,
+} from '../common/config/environment';
 import styles from './styles/who_we_serve.module.css';
 
 const VISIBILITY_OFFSET = 400;
@@ -142,22 +146,15 @@ function WhoWeServe(props) {
 WhoWeServe.getInitialProps = getMemberCount;
 
 async function getMemberCount() {
-  let count = null;
-  const url = '/conversations.members';
-
-  const response = await axios.get(slackApiUrl.concat(url), {
+  const response = await axios.get(slackApiUrl.concat(slackConversationsMembersEndpoint), {
     params: {
       token: process.env.SLACK_API_TOKEN,
       channel: slackGeneralChannelId,
     },
   });
 
-  if (response.data.members !== undefined) {
-    count = response.data.members.length;
-  }
-
   return {
-    memberCount: count,
+    memberCount: response.data.ok ? response.data.members.length : null,
   };
 }
 

--- a/pages/who_we_serve.js
+++ b/pages/who_we_serve.js
@@ -1,3 +1,5 @@
+import axios from 'axios';
+import PropTypes from 'prop-types';
 import TrackVisibility from 'react-on-screen';
 import classNames from 'classnames';
 import Head from 'components/head';
@@ -11,13 +13,7 @@ import CareerServicesIcon from 'static/images/icons/Custom/career_services.svg';
 import MentorshipIcon from 'static/images/icons/Custom/mentorship.svg';
 import ScholarshipsIcon from 'static/images/icons/Custom/scholarships.svg';
 import { s3 } from 'common/constants/urls';
-import axios from 'axios';
-import PropTypes from 'prop-types';
-import {
-  slackApiUrl,
-  slackGeneralChannelId,
-  slackConversationsMembersEndpoint,
-} from '../common/config/environment';
+import { slackMembersAPIUrl, slackGeneralChannelId } from 'common/config/environment';
 import styles from './styles/who_we_serve.module.css';
 
 const VISIBILITY_OFFSET = 400;
@@ -43,6 +39,20 @@ WhoWeServe.propTypes = {
 
 WhoWeServe.defaultProps = {
   memberCount: null,
+};
+
+WhoWeServe.getInitialProps = async () => {
+  const response = await axios.get(slackMembersAPIUrl, {
+    params: {
+      token: process.env.SLACK_API_TOKEN,
+      channel: slackGeneralChannelId,
+    },
+  });
+
+  return {
+    memberCount:
+      response.data.ok && response.data && response ? response.data.members.length : null,
+  };
 };
 
 function WhoWeServe(props) {
@@ -141,21 +151,6 @@ function WhoWeServe(props) {
       <JoinSection />
     </>
   );
-}
-
-WhoWeServe.getInitialProps = getMemberCount;
-
-async function getMemberCount() {
-  const response = await axios.get(slackApiUrl.concat(slackConversationsMembersEndpoint), {
-    params: {
-      token: process.env.SLACK_API_TOKEN,
-      channel: slackGeneralChannelId,
-    },
-  });
-
-  return {
-    memberCount: response.data.ok ? response.data.members.length : null,
-  };
 }
 
 export default WhoWeServe;

--- a/pages/who_we_serve.js
+++ b/pages/who_we_serve.js
@@ -11,6 +11,9 @@ import CareerServicesIcon from 'static/images/icons/Custom/career_services.svg';
 import MentorshipIcon from 'static/images/icons/Custom/mentorship.svg';
 import ScholarshipsIcon from 'static/images/icons/Custom/scholarships.svg';
 import { s3 } from 'common/constants/urls';
+import axios from 'axios';
+import PropTypes from 'prop-types';
+import { slackApiUrl, slackGeneralChannelId } from '../common/config/environment';
 import styles from './styles/who_we_serve.module.css';
 
 const VISIBILITY_OFFSET = 400;
@@ -30,90 +33,132 @@ const mentorItems = [
   },
 ];
 
-export default () => (
-  <>
-    <Head title="Who We Serve" />
+WhoWeServe.propTypes = {
+  memberCount: PropTypes.number,
+};
 
-    <HeroBanner
-      backgroundImageSource={`${s3}redesign/heroBanners/who_we_serve.jpg`}
-      title="We're A Community"
-    />
+WhoWeServe.defaultProps = {
+  memberCount: null,
+};
 
-    <Content
-      title="Who Do We Serve?"
-      theme="gray"
-      columns={[
-        <div>
-          <p className={styles.justifyAlign}>
-            We work closely with military veterans, service members, and spouses who are passionate
-            about transitioning into the tech industry. We work with over 5,000 members who are all
-            working towards relevant goals on Slack and in-person meet-ups. Membership is free!
-          </p>
+function WhoWeServe(props) {
+  const { memberCount } = props;
+  return (
+    <>
+      <Head title="Who We Serve" />
 
-          <div className={classNames(styles.centeredText, styles.topMargin)}>
-            <LinkButton href="/join" theme="secondary">
-              Become A Member
-            </LinkButton>
-          </div>
-        </div>,
-      ]}
-    />
+      <HeroBanner
+        backgroundImageSource={`${s3}redesign/heroBanners/who_we_serve.jpg`}
+        title="We're A Community"
+      />
 
-    <Content
-      columns={[
-        <TrackVisibility offset={VISIBILITY_OFFSET}>
-          <ImageCard
-            alt="Two developers collaborting over some code."
-            imageSource={`${s3}redesign/images/paired_programming.jpg`}
-            isImageFirst
-          >
-            <p className={styles.centeredText}>
-              Currently 1,000,000+ <br /> software development jobs available in the United States.
-            </p>
-          </ImageCard>
-        </TrackVisibility>,
-      ]}
-    />
-
-    <Content
-      title="Our Commitment To You"
-      theme="gray"
-      columns={[
-        <p className={styles.justifyAlign}>
-          Whether you are looking to change careers or starting a new one in the tech industry, we
-          are here to help you succeed by providing:
-        </p>,
-        <div className={styles.badgeGroupings}>
-          {mentorItems.map(item => (
-            <Badge key={item.label} icon={item.icon} label={item.label} className={styles.badge} />
-          ))}
-        </div>,
-      ]}
-    />
-
-    <Content
-      columns={[
-        <TrackVisibility offset={VISIBILITY_OFFSET}>
-          <ImageCard
-            alt="Room full of people chatting at an Operation Code meetup in New York City."
-            imageSource={`${s3}redesign/images/chatting_at_meetup.jpg`}
-          >
-            <p className={styles.centeredText}>
-              We have meetup chapters all around the United States!
+      <Content
+        title="Who Do We Serve?"
+        theme="gray"
+        columns={[
+          <div>
+            <p className={styles.justifyAlign}>
+              We work closely with military veterans, service members, and spouses who are
+              passionate about transitioning into the tech industry. We work with{' '}
+              {!memberCount ? 'over 5,000' : `${memberCount}`} members who are all working towards
+              relevant goals on Slack and in-person meet-ups. Membership is free!
             </p>
 
-            <LinkButton
-              href="https://www.meetup.com/pro/operationcode"
-              analyticsEventLabel="Meetup.com Locations Link"
-              theme="secondary"
+            <div className={classNames(styles.centeredText, styles.topMargin)}>
+              <LinkButton href="/join" theme="secondary">
+                Become A Member
+              </LinkButton>
+            </div>
+          </div>,
+        ]}
+      />
+
+      <Content
+        columns={[
+          <TrackVisibility offset={VISIBILITY_OFFSET}>
+            <ImageCard
+              alt="Two developers collaborting over some code."
+              imageSource={`${s3}redesign/images/paired_programming.jpg`}
+              isImageFirst
             >
-              See Locations
-            </LinkButton>
-          </ImageCard>
-        </TrackVisibility>,
-      ]}
-    />
+              <p className={styles.centeredText}>
+                Currently 1,000,000+ <br /> software development jobs available in the United
+                States.
+              </p>
+            </ImageCard>
+          </TrackVisibility>,
+        ]}
+      />
 
-    <JoinSection />
-  </>
-);
+      <Content
+        title="Our Commitment To You"
+        theme="gray"
+        columns={[
+          <p className={styles.justifyAlign}>
+            Whether you are looking to change careers or starting a new one in the tech industry, we
+            are here to help you succeed by providing:
+          </p>,
+          <div className={styles.badgeGroupings}>
+            {mentorItems.map(item => (
+              <Badge
+                key={item.label}
+                icon={item.icon}
+                label={item.label}
+                className={styles.badge}
+              />
+            ))}
+          </div>,
+        ]}
+      />
+
+      <Content
+        columns={[
+          <TrackVisibility offset={VISIBILITY_OFFSET}>
+            <ImageCard
+              alt="Room full of people chatting at an Operation Code meetup in New York City."
+              imageSource={`${s3}redesign/images/chatting_at_meetup.jpg`}
+            >
+              <p className={styles.centeredText}>
+                We have meetup chapters all around the United States!
+              </p>
+
+              <LinkButton
+                href="https://www.meetup.com/pro/operationcode"
+                analyticsEventLabel="Meetup.com Locations Link"
+                theme="secondary"
+              >
+                See Locations
+              </LinkButton>
+            </ImageCard>
+          </TrackVisibility>,
+        ]}
+      />
+
+      <JoinSection />
+    </>
+  );
+}
+
+WhoWeServe.getInitialProps = getMemberCount;
+
+async function getMemberCount() {
+  let count = null;
+  const url = '/conversations.members';
+
+  const response = await axios.get(slackApiUrl.concat(url), {
+    params: {
+      token: process.env.SLACK_API_TOKEN,
+      channel: slackGeneralChannelId,
+    },
+  });
+
+  if (response.data.members !== undefined) {
+    count = response.data.members.length;
+  }
+
+  return {
+    memberCount: count,
+  };
+}
+
+export default WhoWeServe;


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
This PR resolves issue #1019. Issue 1019 requests that we implement a dynamically updating OC member count on the OC `who_we_serve` page. After some discussion, we decided that the best avenue to pursue getting an active member count is by polling the `conversations.members` endpoint on the Slack API and using that endpoint to return an array of all of the current members in a given channel. More on that [here](https://api.slack.com/methods/conversations.members). 

In `environment.js`, there is a call to check if the app is in production. If it is in production, then use OC `#general` channel, otherwise use whatever channel that you'd like to use in there. 

By default, if the request should fail, then revert to the default text (see screenshot), but if the request is successful, then display the number of 'active users' in OC `#general`. I found this to be useful for cases when the request fails, as it would look a bit odd if there wasn't anything there. 

# Issue Resolved
<!-- Keeping the format 'Fixes #{ISSUE_NUMBER}' will automatically close the issue when this PR is merged -->
Fixes #1019 

## Screenshots/GIFs
<!-- Please provide a view into the feature/bugfix if possible-->
Successful request:
<img width="789" alt="image" src="https://user-images.githubusercontent.com/35318080/76170892-8dec5400-6143-11ea-85c2-94ed0c303949.png">

Failed request to Slack API:
<img width="783" alt="image" src="https://user-images.githubusercontent.com/35318080/76170874-64cbc380-6143-11ea-9b72-32eaf983e9e7.png">

