### PR TITLE
fix: update createComponent.js script to create correctly named css file

### DIFF
--- a/scripts/createComponent/createComponent.js
+++ b/scripts/createComponent/createComponent.js
@@ -24,7 +24,7 @@ const componentStruct = {
           ],
         },
         {
-          'Component.css': buildCss,
+          'Component.module.css': buildCss,
         },
         {
           'Component.js': buildJS,


### PR DESCRIPTION
# Description of changes

Within the createComponent.js script change the object key for creating the components css file from Component.css to Component.module.css in componentStruct object so that the newly created css file is correctly named.


# Issue Resolved

Fixes #1071 

## Screenshots/GIFs

[Screenshot](https://i.imgur.com/GC0kPdr.png) showing desired behavior of create-component after resolving issue.
