### PR TITLE
adjust starting page # when using search endpoint

### DIFF
--- a/pages/resources/[page].js
+++ b/pages/resources/[page].js
@@ -64,7 +64,7 @@ function Resources() {
 
   const handleEndpoint = () => {
     if (q) {
-      return getResourcesBySearch({ page, category, languages, paid, q });
+      return getResourcesBySearch({ page: page - 1, category, languages, paid, q });
     }
     return getResourcesPromise({ page, category, languages, paid });
   };
@@ -298,7 +298,7 @@ function Resources() {
 
                     <Pagination
                       currentPage={currentPage}
-                      totalPages={totalPages || currentPage + 1}
+                      totalPages={totalPages || currentPage}
                       pathname={pathname}
                       query={query}
                     />


### PR DESCRIPTION
# Description of changes
Hotfix for resources page. When using search endpoint, resources are zero indexed and start at `page 0`. Was previously defaulting to `page 1` regardless of endpoint.

## Screenshots/GIFs
<img width="372" alt="resources_search_endpoint" src="https://user-images.githubusercontent.com/41161951/85496364-80d67080-b61f-11ea-81af-ebfd9413044c.png">
<img width="487" alt="resources_query_object" src="https://user-images.githubusercontent.com/41161951/85496369-8338ca80-b61f-11ea-873f-5522f80198cf.png">

