### PR TITLE
Create column layout for challenge name list

### DIFF
--- a/pages/challenge.js
+++ b/pages/challenge.js
@@ -27,7 +27,7 @@ export const MakeColumnsFromArray = ({ ary }) => {
     content.push(
       <div key={col} className={styles.challengerListColumn}>
         {elements.map(element => (
-          <li key={colPersonStartIndex}>{element}</li>
+          <li key={element}>{element}</li>
         ))}
       </div>,
     );

--- a/pages/challenge.js
+++ b/pages/challenge.js
@@ -12,6 +12,32 @@ const RepoLink = 'https://github.com/OperationCode/front-end/';
 const ChallengeLink = `${RepoLink}blob/main/pages/challenge.js`;
 const CompareLink = `${RepoLink}compare`;
 
+export const MakeColumnsFromArray = ({ ary }) => {
+  const numberNamesPerColumn = 20;
+  const numberCols = Math.floor(ary.length / numberNamesPerColumn) + 1;
+
+  const content = [];
+  let col = 0;
+
+  while (col < numberCols) {
+    const colPersonStartIndex = col * numberNamesPerColumn;
+    const colPersonEndIndex = col * numberNamesPerColumn + numberNamesPerColumn;
+    const elements = challengers.slice(colPersonStartIndex, colPersonEndIndex);
+
+    content.push(
+      <div key={col} className={styles.challengerListColumn}>
+        {elements.map(element => (
+          <li key={colPersonStartIndex}>{element}</li>
+        ))}
+      </div>,
+    );
+
+    col += 1;
+  }
+
+  return content;
+};
+
 function Challenge() {
   return (
     <div className={styles.Challenge}>
@@ -177,10 +203,8 @@ function Challenge() {
             <h6 className={styles.centerText}>
               Here is a list of the people that have completed this before you:
             </h6>
-            <ol>
-              {challengers.map(name => (
-                <li key={name}>{name}</li>
-              ))}
+            <ol className={styles.challengerList}>
+              <Content columns={[<MakeColumnsFromArray ary={challengers} />]} />
             </ol>
           </div>,
         ]}

--- a/pages/challenge.js
+++ b/pages/challenge.js
@@ -4,6 +4,7 @@ import HeroBanner from 'components/HeroBanner/HeroBanner';
 import Content from 'components/Content/Content';
 import OutboundLink from 'components/OutboundLink/OutboundLink';
 import challengers from 'static/operationcode_challenge/names';
+import range from 'lodash/range';
 import styles from './styles/challenge.module.css';
 
 const pageTitle = 'Challenge';
@@ -12,28 +13,24 @@ const RepoLink = 'https://github.com/OperationCode/front-end/';
 const ChallengeLink = `${RepoLink}blob/main/pages/challenge.js`;
 const CompareLink = `${RepoLink}compare`;
 
-export const MakeColumnsFromArray = ({ ary }) => {
+export const NamesColumns = () => {
   const numberNamesPerColumn = 20;
-  const numberCols = Math.floor(ary.length / numberNamesPerColumn) + 1;
+  const numberCols = Math.floor(challengers.length / numberNamesPerColumn) + 1;
+  const columns = range(1, numberCols + 1);
 
-  const content = [];
-  let col = 0;
+  const content = columns.map((columnNumber, index) => {
+    const startIndex = index * numberNamesPerColumn;
+    const endIndex = columnNumber * numberNamesPerColumn;
+    const namesInColumn = challengers.slice(startIndex, endIndex);
 
-  while (col < numberCols) {
-    const colPersonStartIndex = col * numberNamesPerColumn;
-    const colPersonEndIndex = col * numberNamesPerColumn + numberNamesPerColumn;
-    const elements = challengers.slice(colPersonStartIndex, colPersonEndIndex);
-
-    content.push(
-      <div key={col} className={styles.challengerListColumn}>
-        {elements.map(element => (
-          <li key={element}>{element}</li>
+    return (
+      <ol key={columnNumber} start={startIndex + 1} className={styles.challengerListColumn}>
+        {namesInColumn.map(name => (
+          <li key={name}>{name}</li>
         ))}
-      </div>,
+      </ol>
     );
-
-    col += 1;
-  }
+  });
 
   return content;
 };
@@ -203,9 +200,9 @@ function Challenge() {
             <h6 className={styles.centerText}>
               Here is a list of the people that have completed this before you:
             </h6>
-            <ol className={styles.challengerList}>
-              <Content columns={[<MakeColumnsFromArray ary={challengers} />]} />
-            </ol>
+            <div className={styles.challengerListContainer}>
+              <Content columns={[<NamesColumns />]} />
+            </div>
           </div>,
         ]}
       />

--- a/pages/styles/challenge.module.css
+++ b/pages/styles/challenge.module.css
@@ -22,3 +22,13 @@
 .Challenge .centerText {
   text-align: center;
 }
+
+.Challenge .challengerList {
+  width: 90vw;
+  padding: 0 10px;
+}
+
+.Challenge .challengerListColumn {
+  align-self: flex-start;
+  margin: 25px;
+}

--- a/pages/styles/challenge.module.css
+++ b/pages/styles/challenge.module.css
@@ -31,6 +31,6 @@
 }
 
 .Challenge .challengerListContainer div {
-  width: 99vw;
+  width: 85vw;
   margin: 0;
 }

--- a/pages/styles/challenge.module.css
+++ b/pages/styles/challenge.module.css
@@ -23,12 +23,14 @@
   text-align: center;
 }
 
-.Challenge .challengerList {
-  width: 90vw;
-  padding: 0 10px;
+.Challenge .challengerListColumn {
+  padding: 0;
+  align-self: flex-start;
+  flex-basis: 225px;
+  list-style-position: inside;
 }
 
-.Challenge .challengerListColumn {
-  align-self: flex-start;
-  margin: 25px;
+.Challenge .challengerListContainer div {
+  width: 99vw;
+  margin: 0;
 }


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Creates a new dynamic column layout for challenger names on the challange page instead of having one continuous list of names. Created to resolve issue 1176
See Slack discussion: https://operation-code.slack.com/archives/C04FASBU9/p1596141056203700
# Issue Resolved
<!-- Keeping the format 'Fixes #{ISSUE_NUMBER}' will automatically close the issue when this PR is merged -->
Fixes #1176 

## Screenshots/GIFs
<!-- Please provide a view into the feature/bugfix if possible-->
Previous layout had a single column which continued to scroll down page as names are added
![image](https://user-images.githubusercontent.com/17321181/89001756-f8975b00-d2af-11ea-8784-e617c6435582.png)

New layout consists of a dynamic column layout that is based on the number of names desired in each column and flexible to the viewport
(Example Pixel2)
![image](https://user-images.githubusercontent.com/17321181/89001857-4ca23f80-d2b0-11ea-9978-c61049b820c6.png)

(Example LargeScreen)
![image](https://user-images.githubusercontent.com/17321181/89002129-24671080-d2b1-11ea-94f7-5157a4898678.png)
