### PR TITLE
Disallow whitespace names during registration on client-side

### DIFF
--- a/components/RegistrationForm/RegistrationForm.js
+++ b/components/RegistrationForm/RegistrationForm.js
@@ -28,8 +28,8 @@ const registrationSchema = Yup.object().shape({
   'confirm-password': Yup.string()
     .required(validationErrorMessages.required)
     .oneOf([Yup.ref('password')], validationErrorMessages.passwordMatch),
-  firstName: Yup.string().required(validationErrorMessages.required),
-  lastName: Yup.string().required(validationErrorMessages.required),
+  firstName: Yup.string().trim().required(validationErrorMessages.required),
+  lastName: Yup.string().trim().required(validationErrorMessages.required),
   zipcode: Yup.string()
     .required(validationErrorMessages.required)
     .test('zipcode', validationErrorMessages.zipcode, isValidZipcode),


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Adds trim function to firstname and lastname fields of registrationSchema in RegistrationForm.js.
As seen in the image below, without the trim feature, a user can enter only whitespace characters in either field.

# Issue Resolved
<!-- Keeping the format 'Fixes #{ISSUE_NUMBER}' will automatically close the issue when this PR is merged -->
Fixes #1145 

## Screenshots/GIFs
<!-- Please provide a view into the feature/bugfix if possible-->
[Image showing firstName field without trim added versus lastName with. (For comparison)](https://slack-files.com/T03GSNF5H-F0183MG4K50-f5a1037ebd)