### PR TITLE
Remove deprecated keys in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,4 @@
 {
-  "version": 2,
-  "name": "operation-code",
-  "alias": ["operation-code.vercel.app", "www.operationcode.org", "operationcode.org"],
   "rewrites": [
     {
       "source": "/media",


### PR DESCRIPTION
# Description of changes

This PR removes deprecated keys. Using the "alias" key can also produce unexpected outcomes
