### PR TITLE
Removed stored user PII in cookies

### DIFF
--- a/common/utils/auth-utils.js
+++ b/common/utils/auth-utils.js
@@ -2,8 +2,8 @@ import Router from 'next/router';
 import nextCookie from 'next-cookies';
 import { setAuthCookies, removeAuthCookies, hasValidAuthToken } from './cookie-utils';
 
-export const login = async ({ token, user }, routeTo = '/profile') => {
-  setAuthCookies({ token, user });
+export const login = async ({ token }, routeTo = '/profile') => {
+  setAuthCookies({ token });
   await Router.push(routeTo);
 };
 

--- a/common/utils/cookie-utils.js
+++ b/common/utils/cookie-utils.js
@@ -1,22 +1,12 @@
 import cookie from 'js-cookie';
 import jwt_decode from 'jwt-decode'; // eslint-disable-line camelcase
 
-export const userInfoCookieNames = ['firstName', 'lastName', 'mentor', 'zipcode'];
-
-export const setAuthCookies = ({ token, user }) => {
+export const setAuthCookies = ({ token }) => {
   cookie.set('token', token);
-
-  userInfoCookieNames.forEach(cookieName => {
-    cookie.set(cookieName, `${user[cookieName]}`);
-  });
 };
 
 export const removeAuthCookies = () => {
   cookie.remove('token');
-
-  userInfoCookieNames.forEach(cookieName => {
-    cookie.remove(cookieName);
-  });
 };
 
 export const setAuthorizationHeader = (token = getAuthToken()) => {

--- a/components/LoginForm/LoginForm.js
+++ b/components/LoginForm/LoginForm.js
@@ -44,9 +44,9 @@ function LoginForm({ initialValues, login, onSuccess }) {
 
   const handleSubmit = async (values, actions) => {
     try {
-      const { user, token } = await login(values);
+      const { token } = await login(values);
 
-      await onSuccess({ token, user });
+      await onSuccess({ token });
       actions.setSubmitting(false);
       actions.resetForm();
     } catch (error) {

--- a/cypress/integration/join.spec.js
+++ b/cypress/integration/join.spec.js
@@ -1,3 +1,4 @@
+import jwt_decode from 'jwt-decode'; // eslint-disable-line camelcase
 import { validationErrorMessages } from '../../common/constants/messages';
 import existingUser from '../../test-utils/mocks/existingUser';
 import mockUser from '../../test-utils/mockGenerators/mockUser';
@@ -396,10 +397,12 @@ describe('join', () => {
     cy.url({ timeout: 10000 }).should('contain', '/profile/update');
     cy.get('h1').should('have.text', 'Update Profile');
 
-    cy.getCookies().then(cookies => {
-      expect(cookies.some(({ value }) => value === validUser.firstName)).to.be.true;
-      expect(cookies.some(({ value }) => value === validUser.lastName)).to.be.true;
-      expect(cookies.some(({ value }) => value === validUser.zipcode)).to.be.true;
+    cy.getCookies().then(([tokenCookie]) => {
+      const jwt = jwt_decode(tokenCookie.value);
+
+      expect(jwt.firstName).to.exist;
+      expect(jwt.lastName).to.exist;
+      expect(jwt.zipcode).to.exist;
     });
 
     cy.findByTestId('Nav Item Login').should('not.exist');

--- a/cypress/integration/login.spec.js
+++ b/cypress/integration/login.spec.js
@@ -1,3 +1,4 @@
+import jwt_decode from 'jwt-decode'; // eslint-disable-line camelcase
 import { networkErrorMessages } from '../../common/constants/messages';
 import existingUser from '../../test-utils/mocks/existingUser';
 import mockPassword from '../../test-utils/mockGenerators/mockPassword';
@@ -26,10 +27,12 @@ describe('login', () => {
     cy.get('h1').should('have.text', 'Profile');
     cy.get(`[data-testid='${PROFILE_GREETING}']`).contains('Hello Kyle Holmberg!');
 
-    cy.getCookies().then(cookies => {
-      expect(cookies.some(({ value }) => value === existingUser.firstName)).to.be.true;
-      expect(cookies.some(({ value }) => value === existingUser.lastName)).to.be.true;
-      expect(cookies.some(({ value }) => value === existingUser.zipcode)).to.be.true;
+    cy.getCookies().then(([tokenCookie]) => {
+      const jwt = jwt_decode(tokenCookie.value);
+
+      expect(jwt.firstName).to.exist;
+      expect(jwt.lastName).to.exist;
+      expect(jwt.zipcode).to.exist;
     });
   });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -15,7 +15,6 @@ import '@testing-library/cypress/add-commands';
 import { addMatchImageSnapshotCommand } from 'cypress-image-snapshot/command';
 import existingUser from '../../test-utils/mocks/existingUser';
 import { apiUrl } from '../../common/config/environment';
-import { userInfoCookieNames } from '../../common/utils/cookie-utils';
 
 Cypress.Commands.add('visitAndWaitFor', path => {
   cy.visit(path);
@@ -32,9 +31,8 @@ Cypress.Commands.add('login', () => {
     body: {
       ...existingUser,
     },
-  }).then(({ body: { token, user } }) => {
+  }).then(({ body: { token } }) => {
     cy.setCookie('token', token);
-    userInfoCookieNames.forEach(cookieName => cy.setCookie(cookieName, `${user[cookieName]}`));
   });
 });
 

--- a/pages/join.js
+++ b/pages/join.js
@@ -21,9 +21,9 @@ function Join({ router }) {
     router.prefetch(profileUpdateURL);
   }, []);
 
-  const handleSuccess = ({ token, user }) => {
+  const handleSuccess = ({ token }) => {
     gtag.conversionEvent({ adId: '9ZvVCOOFmrkBEK-Rnp4D', category: 'sign_up' });
-    login({ token, user }, profileUpdateURL);
+    login({ token }, profileUpdateURL);
   };
 
   return (

--- a/pages/login.js
+++ b/pages/login.js
@@ -59,8 +59,8 @@ function Login({ loggedOut, router }) {
     setAlertMessage('');
   };
 
-  const handleSuccess = ({ token, user }) => {
-    login({ token, user });
+  const handleSuccess = ({ token }) => {
+    login({ token });
   };
 
   const onLogin = values => {


### PR DESCRIPTION
# Description of changes
1. Removed set and remove of the user info cookies in cookie-utils. JWT is still set/removed in util functions.
2. Cleaned up login functions by removing references to user object.
3. Updated e2e tests for removal of PII from cookies; included a check of the decoded JWT cookie instead of the old user info cookies.

# Issue Resolved
Fixes #1146

## Screenshots/GIFs
Before:
![image](https://user-images.githubusercontent.com/36678298/93161727-623cbe80-f6d0-11ea-96fd-e08d1173963d.png)
After:
![image](https://user-images.githubusercontent.com/36678298/93161756-77b1e880-f6d0-11ea-9e12-a4d1d339437e.png)

