### PR TITLE
fix(#1233): use text as children in ImageCard.stories

### DIFF
--- a/components/Cards/ImageCard/__stories__/ImageCard.stories.js
+++ b/components/Cards/ImageCard/__stories__/ImageCard.stories.js
@@ -15,6 +15,6 @@ const Template = arguments_ => <ImageCard {...arguments_} />;
 export const Default = Template.bind({});
 Default.args = {
   alt: 'Image Card',
-  children: <p>{descriptions.long}</p>,
+  children: descriptions.long,
   imageSource: `${s3}redesign/heroBanners/about.jpg`,
 };


### PR DESCRIPTION
# Description of changes
fixes #1233 by using primitive value as children

# Issue Resolved
<!-- Keeping the format 'Fixes #{ISSUE_NUMBER}' will automatically resolve the relevant issue when this PR is merged -->
<!-- If your PR isn't meant to resolve an issue, you can leave this alone! -->
Fixes #1233 

## Screenshots/GIFs
<!-- Please provide a view into the feature/bugfix if possible-->
![image](https://user-images.githubusercontent.com/12544704/94796741-76c2cb80-03df-11eb-8db4-a2cd108ea4b6.png)
