### PR TITLE
Added Secure Code Warrior Logo

### DIFF
--- a/common/constants/partners.js
+++ b/common/constants/partners.js
@@ -79,6 +79,12 @@ const partners = [
     url: 'https://vercel.com/home?utm_source=operationcode',
     type: PARTNER_TYPES.KIND,
   },
+  {
+    name: 'Secure Code Warrior',
+    logoSource: `https://user-images.githubusercontent.com/51661129/92973323-3d540b80-f484-11ea-85dd-d202fc751cd9.png`,
+    url: 'https://securecodewarrior.com/?utm_source=operationcode',
+    type: PARTNER_TYPES.KIND,
+  },
 ];
 
 export default sortBy(partners, 'name');


### PR DESCRIPTION
# Description of changes
- Added Secure Code Warriors Logo in Corporate Supporters Section.
- A link to the secure code warriors site has also been added i.e. if the logo is clicked, it redirects to [This Link](https://securecodewarrior.com/)

# Issue Resolved
Fixes #1211 

## Screenshots/GIFs
The Secure Code Warrior Image has been added in the corporate supporters section with the link to their site.

![image](https://user-images.githubusercontent.com/23498248/94859300-effb0680-0451-11eb-90c0-7c4de4300fe9.png)

