### PR TITLE
feat(#1141): create <SurveyForm /> and create public route /survey

### DIFF
--- a/components/SurveyForm/SurveyForm.js
+++ b/components/SurveyForm/SurveyForm.js
@@ -1,0 +1,145 @@
+import React, { useState } from 'react';
+import { func, number, oneOfType, shape, string } from 'prop-types';
+import { Formik, Field } from 'formik';
+import * as Yup from 'yup';
+import { getServerErrorMessage } from 'common/utils/api-utils';
+import { validationErrorMessages } from 'common/constants/messages';
+import { capitalizeFirstLetter } from 'common/utils/string-utils';
+import Button from 'components/Buttons/Button/Button';
+import Form from 'components/Form/Form';
+import Input from 'components/Form/Input/Input';
+import Alert from 'components/Alert/Alert';
+import styles from './SurveyForm.module.css';
+
+/**
+ * Zipcode issues solved via a trim check from Yup.
+ *
+ * This may seem counter-intuitive, but it's difficult to get a zipcode regex correctly.
+ * See https://stackoverflow.com/questions/578406/what-is-the-ultimate-postal-code-and-zip-regex
+ * for more info
+ *
+ */
+const surveySchema = Yup.object().shape({
+  email: Yup.string()
+    .required(validationErrorMessages.required)
+    .email(validationErrorMessages.email),
+  firstName: Yup.string().trim().required(validationErrorMessages.required),
+  lastName: Yup.string().trim().required(validationErrorMessages.required),
+  zipcode: Yup.string().trim().required(validationErrorMessages.required),
+});
+
+SurveyForm.propTypes = {
+  onSuccess: func,
+  initialValues: shape({
+    email: string,
+    firstName: string,
+    lastName: string,
+    zipcode: oneOfType([string, number]),
+  }),
+};
+
+SurveyForm.defaultProps = {
+  onSuccess: undefined,
+  initialValues: {
+    email: '',
+    firstName: '',
+    lastName: '',
+    zipcode: '',
+  },
+};
+
+function SurveyForm({ initialValues, onSuccess }) {
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleSubmit = async (values, actions) => {
+    try {
+      // TODO: Need backend api to accept survey values.
+      // const { status } = await submitSurvey(values);
+      if (typeof onSuccess === 'function') {
+        await onSuccess();
+      }
+
+      actions.setSubmitting(false);
+      actions.resetForm();
+    } catch (error) {
+      actions.setSubmitting(false);
+
+      const { data } = error.response;
+      if (data) {
+        const newErrorMessage = Object.keys(data)
+          .map(key => {
+            const fieldName = capitalizeFirstLetter(key);
+            return `${fieldName}: ${data[key][0]}.`;
+          })
+          .join('\n');
+
+        setErrorMessage(newErrorMessage);
+      } else {
+        setErrorMessage(getServerErrorMessage(error));
+      }
+    }
+  };
+
+  return (
+    <Formik initialValues={initialValues} onSubmit={handleSubmit} validationSchema={surveySchema}>
+      {({ isSubmitting }) => (
+        <Form className={styles.SurveyForm}>
+          <p>
+            Thank you for your interest in Operation Code! Please fill out the form below so we can
+            stay in touch!
+          </p>
+
+          <div>
+            <Field
+              type="email"
+              name="email"
+              label="Email*"
+              component={Input}
+              disabled={isSubmitting}
+              autoComplete="username email"
+            />
+
+            <Field
+              type="text"
+              name="firstName"
+              label="First Name*"
+              component={Input}
+              disabled={isSubmitting}
+              autoComplete="given-name"
+            />
+
+            <Field
+              type="text"
+              name="lastName"
+              label="Last Name*"
+              component={Input}
+              disabled={isSubmitting}
+              autoComplete="family-name"
+            />
+
+            <Field
+              type="text"
+              name="zipcode"
+              label="Zipcode*"
+              component={Input}
+              disabled={isSubmitting}
+              autoComplete="postal-code"
+            />
+          </div>
+
+          {errorMessage && <Alert type="error">{errorMessage}</Alert>}
+          <Button
+            className={styles.topMargin}
+            type="submit"
+            theme="secondary"
+            disabled={isSubmitting}
+          >
+            Submit
+          </Button>
+        </Form>
+      )}
+    </Formik>
+  );
+}
+
+export default SurveyForm;

--- a/components/SurveyForm/SurveyForm.module.css
+++ b/components/SurveyForm/SurveyForm.module.css
@@ -1,0 +1,14 @@
+.SurveyForm {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+}
+
+.topMargin {
+  margin-top: 1rem;
+}
+
+.SurveyForm > p {
+  margin: 1.25rem auto;
+}

--- a/components/SurveyForm/__tests__/SurveyForm.test.js
+++ b/components/SurveyForm/__tests__/SurveyForm.test.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import createSnapshotTest from 'test-utils/createSnapshotTest';
+import mockUser from 'test-utils/mockGenerators/mockUser';
+import OperationCodeAPIMock from 'test-utils/mocks/apiMock';
+import SurveyForm from '../SurveyForm';
+
+beforeEach(() => {
+  OperationCodeAPIMock.reset();
+});
+
+describe('SurveyForm', () => {
+  const { email, firstName, lastName, zipcode } = mockUser();
+  const initialValues = { email, firstName, lastName, zipcode };
+  it('should render with required props', () => {
+    createSnapshotTest(<SurveyForm />);
+  });
+
+  it('should submit with valid data in form', async () => {
+    const successSpy = jest.fn();
+    const { getByText } = render(
+      <SurveyForm onSuccess={successSpy} initialValues={initialValues} />,
+    );
+
+    fireEvent.click(getByText('Submit'));
+    await waitFor(() => {
+      // TODO: Once this component is connected an api, change this assertion to 1 call.
+      expect(OperationCodeAPIMock.history.post.length).toStrictEqual(0);
+      expect(successSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should reset form and set form as "not submitting" after successful submission', async () => {
+    const successSpy = jest.fn(() => Promise.resolve(true));
+    const { container, getByText, findByText } = render(
+      <SurveyForm onSuccess={successSpy} initialValues={initialValues} />,
+    );
+
+    fireEvent.click(getByText('Submit'));
+
+    const submit = await findByText('Submit');
+    expect(submit).not.toBeDisabled();
+
+    container.querySelectorAll('input').forEach(input => {
+      expect(input.textContent).toBeFalsy();
+    });
+  });
+
+  it('should show an error error if the api call was rejected', async () => {
+    const successSpy = jest.fn().mockRejectedValue({
+      response: {
+        data: {
+          error: 'TODO: Once implemented, mock api and throw an error there instead of this fn.',
+        },
+      },
+    });
+    const { getByText } = render(
+      <SurveyForm onSuccess={successSpy} initialValues={initialValues} />,
+    );
+    fireEvent.click(getByText('Submit'));
+    await waitFor(() => {
+      expect(alert).not.toBeNull();
+    });
+  });
+});

--- a/components/SurveyForm/__tests__/__snapshots__/SurveyForm.test.js.snap
+++ b/components/SurveyForm/__tests__/__snapshots__/SurveyForm.test.js.snap
@@ -1,0 +1,139 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SurveyForm should render with required props 1`] = `
+<form
+  className="SurveyForm"
+  noValidate={true}
+  onReset={[Function]}
+  onSubmit={[Function]}
+>
+  <p>
+    Thank you for your interest in Operation Code! Please fill out the form below so we can stay in touch!
+  </p>
+  <div>
+    <div
+      className="field"
+      data-testid="INPUT"
+    >
+      <label
+        className="Label"
+        data-testid="LABEL"
+        htmlFor="email"
+      >
+        Email*
+      </label>
+      <div
+        className="inputFeedbackGrouping"
+        data-testid="INPUT_FEEDBACK_GROUPING"
+      >
+        <input
+          autoComplete="username email"
+          className="Input"
+          disabled={false}
+          id="email"
+          name="email"
+          onBlur={[Function]}
+          onChange={[Function]}
+          type="email"
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      className="field"
+      data-testid="INPUT"
+    >
+      <label
+        className="Label"
+        data-testid="LABEL"
+        htmlFor="firstName"
+      >
+        First Name*
+      </label>
+      <div
+        className="inputFeedbackGrouping"
+        data-testid="INPUT_FEEDBACK_GROUPING"
+      >
+        <input
+          autoComplete="given-name"
+          className="Input"
+          disabled={false}
+          id="firstName"
+          name="firstName"
+          onBlur={[Function]}
+          onChange={[Function]}
+          type="text"
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      className="field"
+      data-testid="INPUT"
+    >
+      <label
+        className="Label"
+        data-testid="LABEL"
+        htmlFor="lastName"
+      >
+        Last Name*
+      </label>
+      <div
+        className="inputFeedbackGrouping"
+        data-testid="INPUT_FEEDBACK_GROUPING"
+      >
+        <input
+          autoComplete="family-name"
+          className="Input"
+          disabled={false}
+          id="lastName"
+          name="lastName"
+          onBlur={[Function]}
+          onChange={[Function]}
+          type="text"
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      className="field"
+      data-testid="INPUT"
+    >
+      <label
+        className="Label"
+        data-testid="LABEL"
+        htmlFor="zipcode"
+      >
+        Zipcode*
+      </label>
+      <div
+        className="inputFeedbackGrouping"
+        data-testid="INPUT_FEEDBACK_GROUPING"
+      >
+        <input
+          autoComplete="postal-code"
+          className="Input"
+          disabled={false}
+          id="zipcode"
+          name="zipcode"
+          onBlur={[Function]}
+          onChange={[Function]}
+          type="text"
+          value=""
+        />
+      </div>
+    </div>
+  </div>
+  
+  <button
+    className="Button topMargin secondary"
+    data-testid="BUTTON"
+    disabled={false}
+    onClick={[Function]}
+    tabIndex={0}
+    type="submit"
+  >
+    Submit
+  </button>
+</form>
+`;

--- a/pages/survey.js
+++ b/pages/survey.js
@@ -1,0 +1,22 @@
+import Head from 'components/head';
+import HeroBanner from 'components/HeroBanner/HeroBanner';
+import Content from 'components/Content/Content';
+import SurveyForm from 'components/SurveyForm/SurveyForm';
+
+const pageTitle = 'Survey';
+
+Survey.propTypes = {};
+
+function Survey() {
+  return (
+    <>
+      <Head title={pageTitle} />
+
+      <HeroBanner title={pageTitle} />
+
+      <Content theme="gray" columns={[<SurveyForm />]} />
+    </>
+  );
+}
+
+export default Survey;


### PR DESCRIPTION
# Description of changes
Creates a new `<SurveyForm />` component and a new page `/survey` that consumes the component. Both password fields and the email confirmation field have been removed - presumably, those won't be necessary in a survey.

There is no backend api for accepting survey form data so I left one comment in the `handleSubmit()` and a couple comments in the test file, where the test should be changed in the future to assert that the api call is being made.

# Issue Resolved
<!-- Keeping the format 'Fixes #{ISSUE_NUMBER}' will automatically resolve the relevant issue when this PR is merged -->
<!-- If your PR isn't meant to resolve an issue, you can leave this alone! -->
Fixes #1141

## Screenshots/GIFs
<!-- Please provide a view into the feature/bugfix if possible-->
![image](https://user-images.githubusercontent.com/8202335/94985967-a1ac3d00-050f-11eb-8273-85cfb84447ef.png)

