### PR TITLE
Fix modal focus locking

### DIFF
--- a/common/constants/testIDs.js
+++ b/common/constants/testIDs.js
@@ -31,3 +31,6 @@ export const COST_SELECT = 'input#react-select-paid-input';
 export const LANGUAGE_SELECT = 'input#react-select-languages-input';
 export const CATEGORY_SELECT = 'input#react-select-category-input';
 export const PROFILE_GREETING = '[PROFILE_GREETING]';
+export const SCHOOL_CARD_LOCATION_LIST_MODAL_BUTTON = 'SCHOOL_CARD_LOCATION_LIST_MODAL_BUTTON';
+export const SCHOOL_LOCATION_LIST_ITEM = 'SCHOOL_LOCATION_LIST_ITEM';
+export const MODAL_CONTENT = 'MODAL_CONTENT';

--- a/components/Cards/SchoolCard/SchoolCard.js
+++ b/components/Cards/SchoolCard/SchoolCard.js
@@ -11,6 +11,7 @@ import LinkButton from 'components/Buttons/LinkButton/LinkButton';
 import Button from 'components/Buttons/Button/Button';
 import Badge from 'components/Badge/Badge';
 import ScreenReaderOnly from 'components/ScreenReaderOnly/ScreenReaderOnly';
+import { SCHOOL_CARD_LOCATION_LIST_MODAL_BUTTON } from 'common/constants/testIDs';
 import styles from './SchoolCard.module.css';
 
 export const ONLINE_ONLY = 'Online only';
@@ -158,6 +159,7 @@ function SchoolCard({
               label: `${name} | Locations`,
             }}
             onClick={toggleModalClick}
+            data-testid={SCHOOL_CARD_LOCATION_LIST_MODAL_BUTTON}
             className={styles.modalToggler}
           >
             view all

--- a/components/Cards/SchoolCard/__tests__/SchoolCard.test.js
+++ b/components/Cards/SchoolCard/__tests__/SchoolCard.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import createShallowSnapshotTest from 'test-utils/createShallowSnapshotTest';
-import { BUTTON } from 'common/constants/testIDs';
+import { SCHOOL_CARD_LOCATION_LIST_MODAL_BUTTON } from 'common/constants/testIDs';
 import SchoolCard, { getSchoolLocationText, ONLINE_ONLY, UNKNOWN, MULTIPLE } from '../SchoolCard';
 
 const locations = [
@@ -48,7 +48,7 @@ describe('SchoolCard', () => {
 
     expect(toggleModal).not.toHaveBeenCalled();
 
-    fireEvent.click(queryByTestId(BUTTON));
+    fireEvent.click(queryByTestId(SCHOOL_CARD_LOCATION_LIST_MODAL_BUTTON));
 
     expect(toggleModal).toHaveBeenCalledTimes(1);
   });
@@ -61,7 +61,7 @@ describe('SchoolCard', () => {
       <SchoolCard {...requiredProps} locations={arrayOfOneLocation} />,
     );
 
-    expect(queryByTestId(BUTTON)).toBeNull();
+    expect(queryByTestId(SCHOOL_CARD_LOCATION_LIST_MODAL_BUTTON)).toBeNull();
   });
 
   it('should not render a button when passed no locations', () => {
@@ -70,7 +70,7 @@ describe('SchoolCard', () => {
 
     const { queryByTestId } = render(<SchoolCard {...requiredProps} locations={emptyArray} />);
 
-    expect(queryByTestId(BUTTON)).toBeNull();
+    expect(queryByTestId(SCHOOL_CARD_LOCATION_LIST_MODAL_BUTTON)).toBeNull();
   });
 });
 

--- a/components/Cards/SchoolCard/__tests__/__snapshots__/SchoolCard.test.js.snap
+++ b/components/Cards/SchoolCard/__tests__/__snapshots__/SchoolCard.test.js.snap
@@ -98,6 +98,7 @@ exports[`SchoolCard should render with required props 1`] = `
         }
       }
       className="modalToggler"
+      data-testid="SCHOOL_CARD_LOCATION_LIST_MODAL_BUTTON"
       datum=""
       disabled={false}
       fullWidth={false}

--- a/components/Modal/Modal.js
+++ b/components/Modal/Modal.js
@@ -5,7 +5,7 @@ import ReactModal from 'react-modal';
 import { gtag } from 'common/utils/thirdParty/gtag';
 import CardStyles from 'components/Cards/Card/Card.module.css';
 import CloseButton from 'components/Buttons/CloseButton/CloseButton';
-
+import { MODAL_CONTENT } from 'common/constants/testIDs';
 import ModalStyles from './Modal.module.css';
 
 Modal.propTypes = {
@@ -45,7 +45,9 @@ function Modal({
       shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
     >
       <CloseButton onClick={onRequestClose} />
-      <div className={ModalStyles.scrollableContainer}>{children}</div>
+      <div className={ModalStyles.scrollableContainer} data-testid={MODAL_CONTENT}>
+        {children}
+      </div>
     </ReactModal>
   );
 }

--- a/components/Modal/__tests__/__snapshots__/Modal.test.js.snap
+++ b/components/Modal/__tests__/__snapshots__/Modal.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Modal should render with many props assigned 1`] = `
 <body
+  aria-hidden="true"
   class="ReactModal__Body--open"
 >
   <div

--- a/components/Modal/__tests__/__snapshots__/Modal.test.js.snap
+++ b/components/Modal/__tests__/__snapshots__/Modal.test.js.snap
@@ -45,6 +45,7 @@ exports[`Modal should render with many props assigned 1`] = `
         </button>
         <div
           class="scrollableContainer"
+          data-testid="MODAL_CONTENT"
         >
           Test
         </div>

--- a/cypress/integration/code_schools.spec.js
+++ b/cypress/integration/code_schools.spec.js
@@ -1,3 +1,9 @@
+import {
+  MODAL_CONTENT,
+  SCHOOL_CARD_LOCATION_LIST_MODAL_BUTTON,
+  SCHOOL_LOCATION_LIST_ITEM,
+} from 'common/constants/testIDs';
+
 describe('code schools', () => {
   const ReactSelectSelector = 'input#react-select-state_select-input';
 
@@ -60,12 +66,10 @@ describe('code schools', () => {
       cy.findAllByTestId('SchoolCard').should('have.length.greaterThan', 30);
     });
 
-    it('should close when user clicks close button', () => {
-      cy.get('button:contains(view all)').each(button => {
-        cy.wrap(button).click();
-        cy.contains('Close').click();
-        cy.get('.ReactModal_Content').should('not.exist');
-      });
+    it('renders all locations when opening the "view all" modal', () => {
+      cy.findAllByTestId(SCHOOL_CARD_LOCATION_LIST_MODAL_BUTTON).first().click();
+      cy.findByTestId(MODAL_CONTENT).should('exist').and('be.visible');
+      cy.findAllByTestId(SCHOOL_LOCATION_LIST_ITEM).should('have.length.greaterThan', 1);
     });
   });
 });

--- a/cypress/integration/modal.spec.js
+++ b/cypress/integration/modal.spec.js
@@ -1,0 +1,25 @@
+import {
+  CLOSE_BUTTON,
+  MODAL_CONTENT,
+  SCHOOL_CARD_LOCATION_LIST_MODAL_BUTTON,
+} from 'common/constants/testIDs';
+
+describe('when the server responds successfully', () => {
+  beforeEach(() => {
+    cy.visitAndWaitFor('/code_schools');
+    cy.get('h1').should('have.text', 'Code Schools');
+  });
+
+  it('hides the rest of the app for accessibility purposes', () => {
+    cy.get('#__next').should('not.have.attr', 'aria-hide');
+    cy.findAllByTestId(SCHOOL_CARD_LOCATION_LIST_MODAL_BUTTON).first().click();
+    cy.get('#__next').should('have.attr', 'aria-hidden', 'true');
+  });
+
+  it('closes the modal when the x button is clicked', () => {
+    cy.findAllByTestId(SCHOOL_CARD_LOCATION_LIST_MODAL_BUTTON).first().click();
+    cy.findByTestId(MODAL_CONTENT).should('exist').and('be.visible');
+    cy.findByTestId(CLOSE_BUTTON).click();
+    cy.findByTestId(MODAL_CONTENT).should('not.exist');
+  });
+});

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -5,7 +5,7 @@ import '@testing-library/jest-dom/extend-expect';
 jest.mock('./common/utils/thirdParty/gtag');
 
 // React Modal
-ReactModal.setAppElement(document.createElement('div').setAttribute('id', 'app-root'));
+ReactModal.setAppElement('body');
 
 beforeAll(() => {
   const observe = jest.fn();

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "test:e2e:ci": "cypress run --record",
     "test": "cross-env NODE_ENV=test BABEL_ENV=test jest --maxWorkers=2",
     "test:ci": "yarn test --ci --coverage=true --verbose=false --silent=true",
-    "test:changes": "yarn test --changedSince main --verbose=true",
-    "test:changes:watch": "yarn test --changedSince main --watch --verbose=true",
+    "test:changes": "yarn test --changedSince=main --verbose=true",
+    "test:changes:watch": "yarn test:changes --watch",
     "test:watch": "yarn test --watch",
     "test:update-snaps": "yarn test -u"
   },

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -13,7 +13,7 @@ import { clientTokens } from 'common/config/environment';
 import { gtag } from 'common/utils/thirdParty/gtag';
 import Nav from 'components/Nav/Nav';
 import Footer from 'components/Footer/Footer';
-import Modal from 'components/Modal/Modal';
+import ReactModal from 'react-modal';
 import { version } from '../package.json';
 import 'common/styles/globalStyles.css';
 
@@ -102,10 +102,8 @@ class OperationCodeApp extends App {
         Sentry.captureException('FontFaceObserver took too long to resolve. Ignore this.'),
       );
 
-    /* Modal anchor set */
-    if (Modal.setAppElement) {
-      Modal.setAppElement('body');
-    }
+    // Accessibility: Tell application which DOM node to hide during focus-locking of modal
+    ReactModal.setAppElement('#__next');
   }
 
   componentWillUnmount() {

--- a/pages/code_schools.js
+++ b/pages/code_schools.js
@@ -12,6 +12,7 @@ import Modal from 'components/Modal/Modal';
 import { getCodeSchoolsPromise } from 'common/constants/api';
 import States from 'common/constants/dropdown-states-values';
 import { ONE_DAY } from 'common/constants/unitsOfTime';
+import { SCHOOL_LOCATION_LIST_ITEM } from 'common/constants/testIDs';
 import edx from 'static/images/moocs/edx.jpg';
 import treehouse from 'static/images/moocs/treehouse.jpg';
 import udacity from 'static/images/moocs/udacity.jpg';
@@ -114,7 +115,7 @@ function CodeSchools({ allSchools }) {
   const isModalOpen = Boolean(locationsModalInfo.name);
 
   return (
-    <div className={styles.CodeSchools}>
+    <>
       <Head title={pageTitle} />
 
       <HeroBanner title={pageTitle}>
@@ -283,15 +284,26 @@ function CodeSchools({ allSchools }) {
         className={styles.schoolLocationModal}
       >
         <>
-          <h3>{locationsModalInfo.name} Campuses</h3>
-          {locationsModalInfo.locations.map(location => (
-            <div className={styles.schoolLocalModalItem}>
-              {`${location.city}, ${location.state}`}
-            </div>
-          ))}
+          <h4>{locationsModalInfo.name} Campuses</h4>
+
+          <ul className={styles.schoolLocationList}>
+            {locationsModalInfo.locations.map(({ city, state }) => {
+              const location = `${city}, ${state}`;
+
+              return (
+                <li
+                  className={styles.schoolLocalModalItem}
+                  key={location}
+                  data-testid={SCHOOL_LOCATION_LIST_ITEM}
+                >
+                  {location}
+                </li>
+              );
+            })}
+          </ul>
         </>
       </Modal>
-    </div>
+    </>
   );
 }
 

--- a/pages/styles/code_schools.module.css
+++ b/pages/styles/code_schools.module.css
@@ -1,62 +1,68 @@
-.CodeSchools .intro {
+.intro {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   justify-content: flex-start;
 }
 
-.CodeSchools .intro .termDefinition {
+.intro .termDefinition {
   margin: 1rem 2rem;
   max-width: 500px;
 }
 
-.CodeSchools .filterContainer {
+.filterContainer {
   margin: 2rem 0;
   width: 100%;
 }
 
-.CodeSchools .filterContainer > h5 {
+.filterContainer > h5 {
   text-align: center;
 }
 
-.CodeSchools .select {
+.select {
   margin: 0.5rem auto;
   min-width: 20rem;
   width: 90%;
   max-width: 50rem;
 }
 
-.CodeSchools .schoolCardsWrapper {
+.schoolCardsWrapper {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
 }
 
-.CodeSchools .centered {
+.centered {
   margin: 1rem 0;
   text-align: center;
 }
 
-.CodeSchools .schoolLocationModal {
+.schoolLocationModal {
   width: 500px;
 }
 
 @media screen and (--small-viewport) {
-  .CodeSchools .schoolLocationModal {
+  .schoolLocationModal {
     width: 100%;
   }
 }
 
-.CodeSchools .schoolLocationModal > div {
+.schoolLocationModal > div {
   width: 100%;
 }
 
-.CodeSchools .schoolLocalModalItem {
+.schoolLocalModalItem {
   padding: 8px 10px;
   border-bottom: 1px solid var(--gray);
 }
 
-.CodeSchools .schoolLocalModalItem:last-child {
+.schoolLocalModalItem:last-child {
   border-bottom: 0;
   margin-bottom: 15px;
+}
+
+.schoolLocationList {
+  margin: 1rem 0;
+  padding: 0;
+  list-style: none;
 }


### PR DESCRIPTION
# Description of changes
Brought to light in #1264... When a modal opens, it should lock focus by hiding the rest of the app either with `aria-modal` or `aria-hidden`. I was aware of this fact, but failed in my implementation of React Modal initially. I've fixed the problem and added an integration test to protect against future regressions.
