### PR TITLE
PR for "Footer links dont open when clicked on iOS mobile #1277"

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,7 +13,7 @@ const nextConfig = withBundleAnalyzer({
 
   experimental: {
     productionBrowserSourceMaps: true,
-    scrollRestoration: true,
+    scrollRestoration: false,
   },
 
   /** @see https://nextjs.org/docs/api-reference/next.config.js/rewrites */

--- a/next.config.js
+++ b/next.config.js
@@ -13,7 +13,7 @@ const nextConfig = withBundleAnalyzer({
 
   experimental: {
     productionBrowserSourceMaps: true,
-    scrollRestoration: false,
+    scrollRestoration: false, // see: https://github.com/OperationCode/front-end/pull/1280
   },
 
   /** @see https://nextjs.org/docs/api-reference/next.config.js/rewrites */


### PR DESCRIPTION
This PR resolves issue #1277.

Hello, it seemed that the issue was related to Nextjs and it was happening on desktop Safari too. As I was investigating the cause, I noticed that this `SecurityError: Attempt to use history.replaceState() more than 100 times per 30 seconds` error was happening as I scrolled the page, following that I'd not be able to use some of the footer links and this other error `Unhandled Promise Rejection: SecurityError: Attempt to use history.pushState() more than 100 times per 30 seconds` would start firing on click.

I was able to fix the problem by setting `scrollRestoration` to `false` (I can also get rid of it altogether if you want). Let me know what you think!

<img width="327" alt="image" src="https://user-images.githubusercontent.com/35401262/95393594-c5e29200-08f2-11eb-910c-f81dc6839503.png">

<img width="1416" alt="image" src="https://user-images.githubusercontent.com/35401262/95393397-6f755380-08f2-11eb-89ca-744b679a7efc.png">
