### PR TITLE
add navigation to merch store and copy on services page

### DIFF
--- a/common/constants/navigation.js
+++ b/common/constants/navigation.js
@@ -70,6 +70,11 @@ const resources = {
   href: '/resources',
 };
 
+const merchStore = {
+  name: 'Merch Store',
+  href: '/swag',
+};
+
 const logout = {
   name: 'Logout',
   href: '/logout', // has a redirect in Next configuration file.
@@ -90,7 +95,7 @@ const accountGroup = {
 
 const servicesGroup = {
   ...services,
-  sublinks: [events, podcast, resources, codeSchools],
+  sublinks: [merchStore, events, podcast, resources, codeSchools],
 };
 
 const aboutUsGroup = {

--- a/components/Nav/__tests__/__snapshots__/Nav.test.js.snap
+++ b/components/Nav/__tests__/__snapshots__/Nav.test.js.snap
@@ -24,6 +24,10 @@ exports[`Nav should render with no props passed 1`] = `
           "name": "Get Involved",
         },
         Object {
+          "href": "/swag",
+          "name": "Merch Store",
+        },
+        Object {
           "href": "/events",
           "name": "Events",
         },
@@ -101,6 +105,10 @@ exports[`Nav should render with no props passed 1`] = `
             name="Services"
             sublinks={
               Array [
+                Object {
+                  "href": "/swag",
+                  "name": "Merch Store",
+                },
                 Object {
                   "href": "/events",
                   "name": "Events",

--- a/pages/services.js
+++ b/pages/services.js
@@ -18,6 +18,7 @@ import { ONE_WEEK } from 'common/constants/unitsOfTime';
 import { s3 } from 'common/constants/urls';
 import { slackMembersAPIUrl, slackGeneralChannelId } from 'common/config/environment';
 import styles from 'styles/services.module.css';
+import OutboundLink from '../components/OutboundLink/OutboundLink';
 
 const VISIBILITY_OFFSET = 400;
 
@@ -94,6 +95,20 @@ function Services({ numberOfMembers }) {
               <LinkButton href="/join" theme="secondary">
                 Become A Member
               </LinkButton>
+            </div>
+
+            <div>
+              <p className={classNames(styles.centeredText, styles.topMargin)}>
+                Do you love Operation Code? Check out our{' '}
+                <OutboundLink
+                  analyticsEventLabel="Merch Store"
+                  hasIcon
+                  href="https://operationcode.threadless.com/"
+                >
+                  Merch Store
+                </OutboundLink>{' '}
+                and get some swag!
+              </p>
             </div>
           </div>,
         ]}


### PR DESCRIPTION
# Description of changes
Adds tab under services that goes to merch store, and some copy regarding the merch store on the services page.


# Issue Resolved
Fixes #1437

## Screenshots/GIFs
![Screenshot from 2021-04-27 14-47-03](https://user-images.githubusercontent.com/65327579/116317087-bb40fa80-a767-11eb-9782-e6af929bceae.png)
![Screenshot from 2021-04-27 14-46-48](https://user-images.githubusercontent.com/65327579/116317092-bd0abe00-a767-11eb-9f72-a28d7cf93a0a.png)

