### PR TITLE
Fixed Button's top padding to 1rem

### DIFF
--- a/components/Buttons/Button/Button.module.css
+++ b/components/Buttons/Button/Button.module.css
@@ -11,7 +11,7 @@
   vertical-align: middle;
   line-height: 1.25;
   min-width: 175px;
-  padding: 0.75rem;
+  padding: 1rem 0.75rem 0.75rem;
   white-space: nowrap;
   transition: 0.2s linear background-color, 0.2s linear color;
   text-shadow: none;


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
This changed the button's top padding to 1rem, while maintaining the other padding to 0.75rem. This allows the text to be vertically center aligned.

# Issue Resolved
<!-- Keeping the format 'Fixes #{ISSUE_NUMBER}' will automatically resolve the relevant issue when this PR is merged -->
<!-- If your PR isn't meant to resolve an issue, you can leave this alone! -->
Fixes #NA

## Screenshots/GIFs
<!-- Please provide a view into the feature/bugfix if possible-->
