### PR TITLE
Change mas-width to use ch instead of pixels

### DIFF
--- a/common/styles/variables.css
+++ b/common/styles/variables.css
@@ -35,5 +35,5 @@
   --borderRadius: 3px;
   --navBarHeight: 65px;
   --navBarTopGutterHeight: 20px;
-  --typicalMaxWidth: 700px;
+  --typicalMaxWidth: 70ch;
 }

--- a/components/UpgradeBrowserOverlay/UpgradeBrowserOverlay.module.css
+++ b/components/UpgradeBrowserOverlay/UpgradeBrowserOverlay.module.css
@@ -11,7 +11,7 @@
   text-align: center;
   top: 50%;
   transform: translate(-50%, -50%);
-  width: 750px;
+  width: var(--typicalMaxWidth);
 }
 
 .overlay {

--- a/styles/contact.module.css
+++ b/styles/contact.module.css
@@ -14,7 +14,7 @@
 
 .Contact .contactMethod {
   margin: 0 auto 2rem;
-  max-width: 700px; /* keep in sync with paragraph max-width */
+  max-width: var(--typicalMaxWidth);
   font-style: normal;
 }
 

--- a/styles/index.module.css
+++ b/styles/index.module.css
@@ -30,7 +30,7 @@
   align-self: center;
   justify-content: center;
   flex-flow: row wrap;
-  max-width: 900px;
+  max-width: var(--typicalMaxWidth);
 }
 
 .Home .joinThrivingSection {


### PR DESCRIPTION
# Description of changes
Changes the typicalMaxWidth css property to be 70ch, instead of 700 pixels, and change a few calls which had large pixel counts (above 500px) to use it. In practice, it appears that with the current font style/sizes, 70ch works out to about 773px

Changes:
* Contact page (Not the contact section on every page)
* Upgrade browser popup
* partner Logos

Existing calls for typicalMaxWidth:
* p tags (as mentioned in tickets)
* create resource 
* get involved

Large pixel count elements that were NOT changed:
* media-query breakpoints
* imageCard (this made them render as only 1 to a row at max width, which was not as good UI)
* Container.content (this broke the stories section)
* FooterWrapper (this broke alignment)
* desktopNavContainer (this removed all the white space from the navbar)

# Issue Resolved
Fixes #1513 

## Screenshots/GIFs
I'm not so sure about using this for partner logos, as it knocks the alignment off by a bit:
![Screenshot 2021-10-30 203033](https://user-images.githubusercontent.com/5492162/139567064-1a150554-0771-4123-8faa-1a71fd4fe84c.png)
<details><summary>Click here for other pictures (collapsed for size)</summary>
![Screenshot 2021-10-30 202327](https://user-images.githubusercontent.com/5492162/139567060-e965910a-d328-483c-8926-b2838ca8f572.png)


![Screenshot 2021-10-30 202324](https://user-images.githubusercontent.com/5492162/139567061-d3deafb3-0ffe-49d2-b0b2-ac37e38f5bf1.png)


![Screenshot 2021-10-30 202239](https://user-images.githubusercontent.com/5492162/139567062-66d0b79a-9159-402f-9999-2ebbc0bb8cde.png)


![Screenshot 2021-10-30 205151](https://user-images.githubusercontent.com/5492162/139567063-be54ed37-c603-4319-9c7e-b623630eb2a9.png)


![Screenshot 2021-10-30 202727](https://user-images.githubusercontent.com/5492162/139567065-419f03d9-cdbe-4b12-a1e5-f04da72129ad.png)
</details>
