### PR TITLE
#1610 Limit width of page content to match width of nav bar

### DIFF
--- a/components/Cards/FlatCard/FlatCard.module.css
+++ b/components/Cards/FlatCard/FlatCard.module.css
@@ -2,7 +2,7 @@
   box-sizing: border-box;
   margin: 1.5rem 1rem;
   position: relative;
-  max-width: 340px;
+  max-width: 364px;
 }
 
 .rowCenter {

--- a/components/Cards/FlatCard/FlatCard.module.css
+++ b/components/Cards/FlatCard/FlatCard.module.css
@@ -2,7 +2,7 @@
   box-sizing: border-box;
   margin: 1.5rem 1rem;
   position: relative;
-  max-width: 364px;
+  max-width: 400px;
 }
 
 .rowCenter {

--- a/components/Cards/FlatCard/FlatCard.module.css
+++ b/components/Cards/FlatCard/FlatCard.module.css
@@ -2,7 +2,7 @@
   box-sizing: border-box;
   margin: 1.5rem 1rem;
   position: relative;
-  max-width: 400px;
+  max-width: 340px;
 }
 
 .rowCenter {

--- a/components/Container/Container.module.css
+++ b/components/Container/Container.module.css
@@ -22,7 +22,7 @@
   justify-content: center;
   margin: 3.5rem auto;
   width: 92.5%;
-  max-width: 1400px;
+  max-width: 1200px;
 }
 
 @media screen and (--small-viewport) {

--- a/components/Container/Container.module.css
+++ b/components/Container/Container.module.css
@@ -21,8 +21,8 @@
   align-items: center;
   justify-content: center;
   margin: 3.5rem auto;
-  width: 92.5%;
-  max-width: 1200px;
+  width: 100%;
+  max-width: 1400px;
 }
 
 @media screen and (--small-viewport) {

--- a/components/Nav/Nav.module.css
+++ b/components/Nav/Nav.module.css
@@ -14,7 +14,7 @@
 
 .desktopNavContainer {
   margin: 0 auto;
-  max-width: 1200px;
+  max-width: 1400px;
 }
 
 .NavDesktop nav {


### PR DESCRIPTION
# Description of changes
- Changed the max-width of the Container component to 1200px to match the Nav and maintain a feeling of consistency with page margin

- Changed the max-width of the FlatCard component to 364px to accommodate for less horizontal from the Container component and render the MOOC School cards with the original "grid" spacing

# Issue Resolved
Fixes #1610 

## Screenshots/GIFs
**Before - with demo border**
<img width="1440" alt="Screen Shot 2023-05-27 at 12 23 19 AM" src="https://github.com/OperationCode/front-end/assets/46408716/3f602f4f-30e5-407b-a361-e0349cd9e0cd">

**After - without border**
<img width="1440" alt="Screen Shot 2023-05-27 at 12 43 08 AM" src="https://github.com/OperationCode/front-end/assets/46408716/f93ccf08-7eb7-4f4c-a72a-1ff41e9f2274">

**After - with demo border**
<img width="1440" alt="Screen Shot 2023-05-27 at 12 41 28 AM" src="https://github.com/OperationCode/front-end/assets/46408716/81cd5a8b-48d4-409e-9686-78765d221c92">

**After - FlatCard max-width adjustment**
<img width="1440" alt="Screen Shot 2023-05-27 at 12 44 57 AM" src="https://github.com/OperationCode/front-end/assets/46408716/bf8e8249-454f-4d52-8936-06a196c4bd62">

