### PR TITLE
Remove resources link from navigation

### DIFF
--- a/common/constants/navigation.js
+++ b/common/constants/navigation.js
@@ -55,11 +55,6 @@ const codeSchools = {
   href: '/code_schools',
 };
 
-const resources = {
-  name: 'Resources',
-  href: '/resources',
-};
-
 const merchStore = {
   name: 'Merch Store',
   href: '/swag',
@@ -82,7 +77,7 @@ const projectRebuild = {
 
 const servicesGroup = {
   ...services,
-  sublinks: [podcast, resources, codeSchools, projectRebuild],
+  sublinks: [podcast, codeSchools, projectRebuild],
 };
 
 const aboutUsGroup = {
@@ -109,7 +104,7 @@ export const mobileNavItems = flattenDepth(
 // MARK: Footer items
 export const footerItems = {
   column1: [about, contact, faq, services],
-  column2: [codeSchools, resources, jobs],
+  column2: [codeSchools, jobs],
   column3: [getInvolved, podcast, history, donate],
   column4: [
     {

--- a/components/Footer/__tests__/__snapshots__/Footer.test.js.snap
+++ b/components/Footer/__tests__/__snapshots__/Footer.test.js.snap
@@ -106,15 +106,6 @@ exports[`Footer should render with no props passed 1`] = `
           </li>
           <li>
             <ForwardRef(LinkComponent)
-              href="/resources"
-            >
-              <a>
-                Resources
-              </a>
-            </ForwardRef(LinkComponent)>
-          </li>
-          <li>
-            <ForwardRef(LinkComponent)
               href="/jobs"
             >
               <a>

--- a/components/Nav/__tests__/__snapshots__/Nav.test.js.snap
+++ b/components/Nav/__tests__/__snapshots__/Nav.test.js.snap
@@ -20,10 +20,6 @@ exports[`Nav should render with no props passed 1`] = `
           "name": "Podcast",
         },
         Object {
-          "href": "/resources",
-          "name": "Resources",
-        },
-        Object {
           "href": "/code_schools",
           "name": "Code Schools",
         },
@@ -117,10 +113,6 @@ exports[`Nav should render with no props passed 1`] = `
                 Object {
                   "href": "/podcast",
                   "name": "Podcast",
-                },
-                Object {
-                  "href": "/resources",
-                  "name": "Resources",
                 },
                 Object {
                   "href": "/code_schools",


### PR DESCRIPTION
# Description of changes
- Removed the `resources` list item object, and its references from `constants/navigation.js`
- Updated Cypress snapshot

# Issue Resolved
Fixes #1709 

## Screenshots/GIFs
![resources1final](https://github.com/OperationCode/front-end/assets/46408716/e6abc03b-dad1-4f09-b1c4-51d6ebc4d637)
![resources2final](https://github.com/OperationCode/front-end/assets/46408716/a1c01430-dc7b-424f-b8b4-55ea779a3e58)
