### PR TITLE
fixed that text shift in faq when chevron clicked

### DIFF
--- a/components/Accordion/Accordion.module.css
+++ b/components/Accordion/Accordion.module.css
@@ -22,10 +22,8 @@
 .icon {
   fill: currentcolor;
   position: absolute;
-
-  /* Should correspond with heading content height (vertically centered with rest of content */
+  top: 1.25rem; /* Should correspond with heading content height (vertically centered with rest of content */
   right: 1.25rem;
-  top: 20px;
   width: 30px;
 }
 

--- a/components/Accordion/Accordion.module.css
+++ b/components/Accordion/Accordion.module.css
@@ -22,8 +22,10 @@
 .icon {
   fill: currentcolor;
   position: absolute;
-  top: 1.25rem; /* Should correspond with heading content height (vertically centered with rest of content */
+
+  /* Should correspond with heading content height (vertically centered with rest of content */
   right: 1.25rem;
+  top: 20px;
   width: 30px;
 }
 

--- a/components/Accordion/Accordion.tsx
+++ b/components/Accordion/Accordion.tsx
@@ -35,7 +35,7 @@ export type AccordionPropsType = {
   className?: string;
   /**
    * Should Accordion have animation on hover.
-   * @default - false  
+   * @default - false
    */
   hasAnimationOnHover?: boolean;
 };
@@ -59,7 +59,7 @@ function Accordion({
 
   return (
     <Card
-      className={classNames(styles.Accordion, className)}
+      className={classNames(styles.Accordion, className, 'justify-normal')}
       hasAnimationOnHover={hasAnimationOnHover}
     >
       <div className={styles.headingContainer}>{content.headingChildren}</div>

--- a/styles/faq.module.css
+++ b/styles/faq.module.css
@@ -11,5 +11,5 @@
 
 .FAQ .FAQAccordion > button > svg {
   fill: currentcolor;
-  top: 0.825rem;
+  top: 1.25rem;
 }


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->

# Issue Resolved
<!-- Keeping the format 'Fixes #{ISSUE_NUMBER}' will automatically resolve the relevant issue when this PR is merged -->
<!-- If your PR isn't meant to resolve an issue, you can leave this alone! -->
Fixes #NA
in the FAQ section, when use expands accordian, there is a text shift that happens..

## Screenshots/GIFs
<!-- Please provide a view into the feature/bugfix if possible-->
![Screenshot 2024-06-19 at 10 27 52 AM](https://github.com/OperationCode/front-end/assets/129689060/b2f5bce6-edf2-4e58-96d5-f5f0be0a0539)
