### PR TITLE
Navlink merch store target fix

### DIFF
--- a/common/constants/navigation.js
+++ b/common/constants/navigation.js
@@ -3,109 +3,92 @@ import flattenDepth from 'lodash/flattenDepth';
 const donate = {
   href: '/donate',
   name: 'Donate',
-  target: '_self',
 };
 
 const services = {
   name: 'Services',
   href: '/services',
-  target: '_self',
 };
 
 const about = {
   name: 'About Us',
   href: '/about',
-  target: '_self',
 };
 
 const history = {
   name: 'History',
   href: '/history',
-  target: '_self',
 };
 
 const team = {
   name: 'Our Team',
   href: '/team',
-  target: '_self',
 };
 
 const contact = {
   name: 'Contact Us',
   href: '/contact',
-  target: '_self',
 };
 
 const faq = {
   name: 'FAQ',
   href: '/faq',
-  target: '_self',
 };
 
 const podcast = {
   name: 'Podcast',
   href: '/podcast',
-  target: '_self',
 };
 
 const branding = {
   name: 'Branding',
   href: '/branding',
-  target: '_self',
 };
 
 const getInvolved = {
   name: 'Get Involved',
   href: '/get_involved',
-  target: '_self',
 };
 
 const merchStore = {
   name: 'Merch Store',
   href: '/swag',
-  target: '_blank',
+  isExternal: true,
 };
 
 const jobs = {
   href: '/jobs',
   name: 'Job Board',
-  target: '_self',
 };
 
 const chapters = {
   name: 'Chapters',
   href: '/chapters',
-  target: '_self',
 };
 
 const sponsorship = {
   name: 'Sponsorship',
   href: '/sponsorship',
-  target: '_self',
 };
 
 const scholarship = {
   name: 'Scholarship',
   href: '/scholarship',
-  target: '_self',
 };
 
 const projectRebuild = {
   name: 'Project Rebuild',
   href: '/project_rebuild',
-  target: '_self',
 };
 
 const press = {
   name: 'Press',
   href: '/press',
-  target: '_self',
 };
 
 const corporateTraining = {
   name: 'Corporate Training',
   href: '/corporate-training',
-  target: '_self',
 };
 
 const servicesGroup = {

--- a/common/constants/navigation.js
+++ b/common/constants/navigation.js
@@ -3,91 +3,109 @@ import flattenDepth from 'lodash/flattenDepth';
 const donate = {
   href: '/donate',
   name: 'Donate',
+  target: '_self',
 };
 
 const services = {
   name: 'Services',
   href: '/services',
+  target: '_self',
 };
 
 const about = {
   name: 'About Us',
   href: '/about',
+  target: '_self',
 };
 
 const history = {
   name: 'History',
   href: '/history',
+  target: '_self',
 };
 
 const team = {
   name: 'Our Team',
   href: '/team',
+  target: '_self',
 };
 
 const contact = {
   name: 'Contact Us',
   href: '/contact',
+  target: '_self',
 };
 
 const faq = {
   name: 'FAQ',
   href: '/faq',
+  target: '_self',
 };
 
 const podcast = {
   name: 'Podcast',
   href: '/podcast',
+  target: '_self',
 };
 
 const branding = {
   name: 'Branding',
   href: '/branding',
+  target: '_self',
 };
 
 const getInvolved = {
   name: 'Get Involved',
   href: '/get_involved',
+  target: '_self',
 };
 
 const merchStore = {
   name: 'Merch Store',
   href: '/swag',
+  target: '_blank',
 };
 
 const jobs = {
   href: '/jobs',
   name: 'Job Board',
+  target: '_self',
 };
 
 const chapters = {
   name: 'Chapters',
   href: '/chapters',
+  target: '_self',
 };
 
 const sponsorship = {
   name: 'Sponsorship',
   href: '/sponsorship',
+  target: '_self',
 };
 
 const scholarship = {
   name: 'Scholarship',
   href: '/scholarship',
+  target: '_self',
 };
 
 const projectRebuild = {
   name: 'Project Rebuild',
   href: '/project_rebuild',
+  target: '_self',
 };
 
 const press = {
   name: 'Press',
   href: '/press',
+  target: '_self',
 };
 
 const corporateTraining = {
   name: 'Corporate Training',
   href: '/corporate-training',
+  target: '_self',
 };
 
 const servicesGroup = {

--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -7,82 +7,93 @@ import Logo from 'public/static/images/logo.svg';
 import { desktopNavItems, mobileNavItems } from 'common/constants/navigation';
 import NavMobile from 'components/Nav/NavMobile/NavMobile';
 import dynamic from 'next/dynamic';
+import { twMerge } from 'tailwind-merge';
 import UserLogo from '../../public/static/images/icons/FontAwesome/user.svg';
 import styles from './Nav.module.css';
 
 const NavListItem = dynamic(() => import('components/Nav/NavListItem/NavListItem'), { ssr: false });
 
 export const Nav = () => {
-    const [isMobileNavOpen, setMobileNavOpen] = useState(false);
+  const [isMobileNavOpen, setMobileNavOpen] = useState(false);
 
-    const openMobileMenu = () => {
-        setMobileNavOpen(true);
-        document.body.style.overflow = 'hidden';
+  const openMobileMenu = () => {
+    setMobileNavOpen(true);
+    document.body.style.overflow = 'hidden';
+  };
+
+  const closeMobileMenu = () => {
+    setMobileNavOpen(false);
+    document.body.style.overflow = 'auto';
+  };
+
+  useEffect(() => {
+    Router.events.on('routeChangeComplete', closeMobileMenu);
+
+    return () => {
+      Router.events.off('routeChangeComplete', closeMobileMenu);
     };
+  }, []);
 
-    const closeMobileMenu = () => {
-        setMobileNavOpen(false);
-        document.body.style.overflow = 'auto';
-    };
+  return (
+    <>
+      {/* Always rendered, but conditionally displayed via media query */}
+      <NavMobile
+        isOpen={isMobileNavOpen}
+        closeMenu={closeMobileMenu}
+        openMenu={openMobileMenu}
+        navItems={mobileNavItems}
+      />
 
-    useEffect(() => {
-        Router.events.on('routeChangeComplete', closeMobileMenu);
+      <header className={styles.NavDesktop}>
+        <div className={styles.desktopNavContainer} data-testid="Desktop Nav Container">
+          <nav data-testid="Desktop Nav">
+            <Link href="/" key="Home">
+              <a
+                className={classNames(
+                  styles.logoLink,
+                  twMerge(styles.link, '[&>svg]:-bottom-2 [&>svg]:right-3'),
+                )}
+                onContextMenu={event => {
+                  event.preventDefault();
+                  Router.push('/branding');
+                }}
+              >
+                <Logo className={styles.logo} style={{ width: 224, height: 42 }} fill="#f7f7f7" />
+              </a>
+            </Link>
 
-        return () => {
-            Router.events.off('routeChangeComplete', closeMobileMenu);
-        };
-    }, []);
+            <ul className={twMerge(styles.link, '[&>svg]:-bottom-2 [&>svg]:right-3')}>
+              {desktopNavItems.map(navItem => (
+                <NavListItem
+                  key={navItem.name}
+                  {...navItem}
+                  icon={
+                    'icon' in navItem && navItem.icon === 'UserLogo' ? (
+                      <UserLogo className={styles.navIcon} />
+                    ) : null
+                  }
+                />
+              ))}
 
-    return (
-        <>
-            {/* Always rendered, but conditionally displayed via media query */}
-            <NavMobile
-                isOpen={isMobileNavOpen}
-                closeMenu={closeMobileMenu}
-                openMenu={openMobileMenu}
-                navItems={mobileNavItems}
-            />
-
-            <header className={styles.NavDesktop}>
-                <div className={styles.desktopNavContainer} data-testid="Desktop Nav Container">
-                    <nav data-testid="Desktop Nav">
-                        <Link href="/" key="Home">
-                            <a
-                                className={classNames(styles.logoLink, styles.link)}
-                                onContextMenu={event => {
-                                    event.preventDefault();
-                                    Router.push('/branding');
-                                }}
-                            >
-                                <Logo className={styles.logo} style={{ width: 224, height: 42 }} fill="#f7f7f7" />
-                            </a>
-                        </Link>
-
-                        <ul className={styles.link}>
-                            {desktopNavItems.map(navItem => (
-                                <NavListItem
-                                    key={navItem.name}
-                                    {...navItem}
-                                    icon={
-                                        'icon' in navItem && navItem.icon === 'UserLogo' ? (
-                                            <UserLogo className={styles.navIcon} />
-                                        ) : null
-                                    }
-                                />
-                            ))}
-
-                            {/* stylistic one-off */}
-                            <li key="Donate">
-                                <Link href="/donate">
-                                    <a className={classNames(styles.link, styles.donateLink)}>Donate</a>
-                                </Link>
-                            </li>
-                        </ul>
-                    </nav>
-                </div>
-            </header>
-        </>
-    );
+              {/* stylistic one-off */}
+              <li key="Donate">
+                <Link href="/donate">
+                  <a
+                    className={classNames(
+                      twMerge(styles.link, '[&>svg]:-bottom-2 [&>svg]:right-3'),
+                      styles.donateLink,
+                    )}
+                  >
+                    Donate
+                  </a>
+                </Link>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </header>
+    </>
+  );
 };
 
 export default Nav;

--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -13,76 +13,76 @@ import styles from './Nav.module.css';
 const NavListItem = dynamic(() => import('components/Nav/NavListItem/NavListItem'), { ssr: false });
 
 export const Nav = () => {
-  const [isMobileNavOpen, setMobileNavOpen] = useState(false);
+    const [isMobileNavOpen, setMobileNavOpen] = useState(false);
 
-  const openMobileMenu = () => {
-    setMobileNavOpen(true);
-    document.body.style.overflow = 'hidden';
-  };
-
-  const closeMobileMenu = () => {
-    setMobileNavOpen(false);
-    document.body.style.overflow = 'auto';
-  };
-
-  useEffect(() => {
-    Router.events.on('routeChangeComplete', closeMobileMenu);
-
-    return () => {
-      Router.events.off('routeChangeComplete', closeMobileMenu);
+    const openMobileMenu = () => {
+        setMobileNavOpen(true);
+        document.body.style.overflow = 'hidden';
     };
-  }, []);
 
-  return (
-    <>
-      {/* Always rendered, but conditionally displayed via media query */}
-      <NavMobile
-        isOpen={isMobileNavOpen}
-        closeMenu={closeMobileMenu}
-        openMenu={openMobileMenu}
-        navItems={mobileNavItems}
-      />
+    const closeMobileMenu = () => {
+        setMobileNavOpen(false);
+        document.body.style.overflow = 'auto';
+    };
 
-      <header className={styles.NavDesktop}>
-        <div className={styles.desktopNavContainer} data-testid="Desktop Nav Container">
-          <nav data-testid="Desktop Nav">
-            <Link href="/" key="Home">
-              <a
-                className={classNames(styles.logoLink, styles.link)}
-                onContextMenu={event => {
-                  event.preventDefault();
-                  Router.push('/branding');
-                }}
-              >
-                <Logo className={styles.logo} style={{ width: 224, height: 42 }} fill="#f7f7f7" />
-              </a>
-            </Link>
+    useEffect(() => {
+        Router.events.on('routeChangeComplete', closeMobileMenu);
 
-            <ul className={styles.link}>
-              {desktopNavItems.map(navItem => (
-                <NavListItem
-                  key={navItem.name}
-                  {...navItem}
-                  icon={
-                    'icon' in navItem && navItem.icon === 'UserLogo' ? (
-                      <UserLogo className={styles.navIcon} />
-                    ) : null
-                  }
-                />
-              ))}
+        return () => {
+            Router.events.off('routeChangeComplete', closeMobileMenu);
+        };
+    }, []);
 
-              {/* stylistic one-off */}
-              <li key="Donate">
-                <Link href="/donate">
-                  <a className={classNames(styles.link, styles.donateLink)}>Donate</a>
-                </Link>
-              </li>
-            </ul>
-          </nav>
-        </div>
-      </header>
-    </>
-  );
+    return (
+        <>
+            {/* Always rendered, but conditionally displayed via media query */}
+            <NavMobile
+                isOpen={isMobileNavOpen}
+                closeMenu={closeMobileMenu}
+                openMenu={openMobileMenu}
+                navItems={mobileNavItems}
+            />
+
+            <header className={styles.NavDesktop}>
+                <div className={styles.desktopNavContainer} data-testid="Desktop Nav Container">
+                    <nav data-testid="Desktop Nav">
+                        <Link href="/" key="Home">
+                            <a
+                                className={classNames(styles.logoLink, styles.link)}
+                                onContextMenu={event => {
+                                    event.preventDefault();
+                                    Router.push('/branding');
+                                }}
+                            >
+                                <Logo className={styles.logo} style={{ width: 224, height: 42 }} fill="#f7f7f7" />
+                            </a>
+                        </Link>
+
+                        <ul className={styles.link}>
+                            {desktopNavItems.map(navItem => (
+                                <NavListItem
+                                    key={navItem.name}
+                                    {...navItem}
+                                    icon={
+                                        'icon' in navItem && navItem.icon === 'UserLogo' ? (
+                                            <UserLogo className={styles.navIcon} />
+                                        ) : null
+                                    }
+                                />
+                            ))}
+
+                            {/* stylistic one-off */}
+                            <li key="Donate">
+                                <Link href="/donate">
+                                    <a className={classNames(styles.link, styles.donateLink)}>Donate</a>
+                                </Link>
+                            </li>
+                        </ul>
+                    </nav>
+                </div>
+            </header>
+        </>
+    );
 };
 
 export default Nav;

--- a/components/Nav/NavListItem/NavListItem.tsx
+++ b/components/Nav/NavListItem/NavListItem.tsx
@@ -9,7 +9,7 @@ import styles from './NavListItem.module.css';
 type SublinkType = {
     name: string;
     href: string;
-    isExternal: boolean;
+    isExternal?: boolean;
 };
 
 export type NavListItemPropsType = {
@@ -22,10 +22,6 @@ export type NavListItemPropsType = {
      */
     href: string;
     /**
-     * Url to be passed to the base anchor element.
-     */
-    isExternal?: boolean;
-    /**
      * List of child links containing the `name` and `href`
      */
     sublinks?: SublinkType[];
@@ -35,7 +31,7 @@ export type NavListItemPropsType = {
     icon?: React.ReactElement | null;
 };
 
-function NavListItem({ sublinks, href, name, icon = null, isExternal = false }: NavListItemPropsType) {
+function NavListItem({ sublinks, href, name, icon = null}: NavListItemPropsType) {
     const [areSublinksVisible, setSublinksVisible] = useState(false);
 
     const handleKeyDown = (event: React.KeyboardEvent, indexKeyedOn: number) => {
@@ -121,6 +117,7 @@ function NavListItem({ sublinks, href, name, icon = null, isExternal = false }: 
                                     <OutboundLink
                                         analyticsEventLabel={`Clicked on ${sublink.name} -> ${sublink.href}`}
                                         href={sublink.href}
+                                        // children={<span className={styles.link}>{sublink.name}</span>}
                                         children={<span className={styles.link}>{sublink.name}</span>}
                                         hasIcon={false}
                                     />

--- a/components/Nav/NavListItem/NavListItem.tsx
+++ b/components/Nav/NavListItem/NavListItem.tsx
@@ -6,118 +6,124 @@ import MinusIcon from 'static/images/icons/minus.svg';
 import styles from './NavListItem.module.css';
 
 type SublinkType = {
-  name: string;
-  href: string;
+    name: string;
+    href: string;
+    target: string;
 };
 
 export type NavListItemPropsType = {
-  /**
-   * Text used for the label.
-   */
-  name: string;
-  /**
-   * Url to be passed to the base anchor element.
-   */
-  href: string;
-  /**
-   * List of child links containing the `name` and `href`
-   */
-  sublinks?: SublinkType[];
-  /**
-   * Includes an optional icon.
-   */
-  icon?: React.ReactElement | null;
+    /**
+     * Text used for the label.
+     */
+    name: string;
+    /**
+     * Url to be passed to the base anchor element.
+     */
+    href: string;
+    /**
+     * Target attribute to be passed to the base anchor element.
+     */
+    target: string;
+    /**
+     * List of child links containing the `name` and `href`
+     */
+    sublinks?: SublinkType[];
+    /**
+     * Includes an optional icon.
+     */
+    icon?: React.ReactElement | null;
 };
 
-function NavListItem({ sublinks, href, name, icon = null }: NavListItemPropsType) {
-  const [areSublinksVisible, setSublinksVisible] = useState(false);
+function NavListItem({ sublinks, href, name, target, icon = null }: NavListItemPropsType) {
+    const [areSublinksVisible, setSublinksVisible] = useState(false);
 
-  const handleKeyDown = (event: React.KeyboardEvent, indexKeyedOn: number) => {
-    const lastSublinkIndex = sublinks && sublinks.length - 1;
-    const isLastSublink = indexKeyedOn === lastSublinkIndex;
-    const isFirstSublink = indexKeyedOn === 0;
+    const handleKeyDown = (event: React.KeyboardEvent, indexKeyedOn: number) => {
+        const lastSublinkIndex = sublinks && sublinks.length - 1;
+        const isLastSublink = indexKeyedOn === lastSublinkIndex;
+        const isFirstSublink = indexKeyedOn === 0;
 
-    const didHitTab = event.key === 'Tab';
-    const didTabForward = didHitTab && !event.shiftKey;
-    const didTabBackward = didHitTab && event.shiftKey;
+        const didHitTab = event.key === 'Tab';
+        const didTabForward = didHitTab && !event.shiftKey;
+        const didTabBackward = didHitTab && event.shiftKey;
 
-    const shouldHideSublinks =
-      (isLastSublink && didTabForward) || (isFirstSublink && didTabBackward);
+        const shouldHideSublinks =
+            (isLastSublink && didTabForward) || (isFirstSublink && didTabBackward);
 
-    if (shouldHideSublinks) {
-      setSublinksVisible(false);
-    }
-  };
+        if (shouldHideSublinks) {
+            setSublinksVisible(false);
+        }
+    };
 
-  const hasSublinks = sublinks && sublinks.length > 0;
-  const exposeSublinks = () => setSublinksVisible(true);
-  const hideSublinks = () => setSublinksVisible(false);
-  const invertSublinkVisibility = () => setSublinksVisible(previousState => !previousState);
+    const hasSublinks = sublinks && sublinks.length > 0;
+    const exposeSublinks = () => setSublinksVisible(true);
+    const hideSublinks = () => setSublinksVisible(false);
+    const invertSublinkVisibility = () => setSublinksVisible(previousState => !previousState);
 
-  return (
-    <li className={styles.NavListItem}>
-      <Link href={href}>
-        <a
-          className={classNames(styles.link, styles.navItemLink)}
-          onMouseEnter={exposeSublinks}
-          onMouseLeave={hideSublinks}
-          role="link"
-          tabIndex={0}
-          data-testid={`Nav Item ${name}`}
-        >
-          <span className={styles.linkContent}>{name}</span>
-          {icon && icon}
-        </a>
-      </Link>
-
-      {hasSublinks && (
-        <>
-          <button
-            aria-expanded={areSublinksVisible}
-            aria-haspopup={hasSublinks}
-            aria-label="submenu"
-            className={styles.sublinkToggleButton}
-            onClick={invertSublinkVisibility}
-            onMouseEnter={exposeSublinks}
-            onMouseLeave={hideSublinks}
-            type="button"
-          >
-            {areSublinksVisible ? (
-              <MinusIcon className={styles.icon} data-testid="minus-icon" />
-            ) : (
-              <PlusIcon className={styles.icon} data-testid="plus-icon" />
-            )}
-          </button>
-
-          <ul
-            className={classNames(styles.sublinksList, {
-              [styles.invisible]: !areSublinksVisible,
-            })}
-            onMouseEnter={exposeSublinks}
-            onMouseLeave={hideSublinks}
-          >
-            {sublinks.map((sublink, index) => (
-              <li className={styles.sublinkListItem} key={sublink.name}>
-                {/* 😞 next/link fought being mocked, so `prefetch` has test-specific code */}
-                <Link href={sublink.href} prefetch={process.env.NODE_ENV === 'production'}>
-                  <a
-                    className={styles.link}
-                    key={sublink.name}
+    return (
+        <li className={styles.NavListItem}>
+            <Link href={href}>
+                <a
+                    className={classNames(styles.link, styles.navItemLink)}
+                    onMouseEnter={exposeSublinks}
+                    onMouseLeave={hideSublinks}
                     role="link"
                     tabIndex={0}
-                    data-testid={`Nav Item ${sublink.name}`}
-                    onKeyDown={event => handleKeyDown(event, index)}
-                  >
-                    <span className={styles.linkContent}>{sublink.name}</span>
-                  </a>
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </>
-      )}
-    </li>
-  );
+                    data-testid={`Nav Item ${name}`}
+                >
+                    <span className={styles.linkContent}>{name}</span>
+                    {icon && icon}
+                </a>
+            </Link>
+
+            {hasSublinks && (
+                <>
+                    <button
+                        aria-expanded={areSublinksVisible}
+                        aria-haspopup={hasSublinks}
+                        aria-label="submenu"
+                        className={styles.sublinkToggleButton}
+                        onClick={invertSublinkVisibility}
+                        onMouseEnter={exposeSublinks}
+                        onMouseLeave={hideSublinks}
+                        type="button"
+                    >
+                        {areSublinksVisible ? (
+                            <MinusIcon className={styles.icon} data-testid="minus-icon" />
+                        ) : (
+                            <PlusIcon className={styles.icon} data-testid="plus-icon" />
+                        )}
+                    </button>
+
+                    <ul
+                        className={classNames(styles.sublinksList, {
+                            [styles.invisible]: !areSublinksVisible,
+                        })}
+                        onMouseEnter={exposeSublinks}
+                        onMouseLeave={hideSublinks}
+                    >
+                        {sublinks.map((sublink, index) => (
+                            <li className={styles.sublinkListItem} key={sublink.name}>
+                                {/* 😞 next/link fought being mocked, so `prefetch` has test-specific code */}
+                                <Link href={sublink.href} prefetch={process.env.NODE_ENV === 'production'}>
+                                    <a
+                                        className={styles.link}
+                                        key={sublink.name}
+                                        role="link"
+                                        tabIndex={0}
+                                        data-testid={`Nav Item ${sublink.name}`}
+                                        onKeyDown={event => handleKeyDown(event, index)}
+                                        target={sublink.target}
+                                    >
+                                        <span className={styles.linkContent}>{sublink.name}</span>
+                                    </a>
+                                </Link>
+                            </li>
+                        ))}
+                    </ul>
+                </>
+            )}
+        </li>
+    );
 }
 
 export default NavListItem;

--- a/components/Nav/NavListItem/NavListItem.tsx
+++ b/components/Nav/NavListItem/NavListItem.tsx
@@ -6,13 +6,13 @@ import MinusIcon from 'static/images/icons/minus.svg';
 import OutboundLink from 'components/OutboundLink/OutboundLink';
 import styles from './NavListItem.module.css';
 
-type SublinkType = {
+interface SublinkType {
     name: string;
     href: string;
     isExternal?: boolean;
 };
 
-export type NavListItemPropsType = {
+export interface NavListItemPropsType {
     /**
      * Text used for the label.
      */
@@ -29,7 +29,7 @@ export type NavListItemPropsType = {
      * Includes an optional icon.
      */
     icon?: React.ReactElement | null;
-};
+}
 
 function NavListItem({ sublinks, href, name, icon = null}: NavListItemPropsType) {
     const [areSublinksVisible, setSublinksVisible] = useState(false);
@@ -116,11 +116,15 @@ function NavListItem({ sublinks, href, name, icon = null}: NavListItemPropsType)
                                 ) : (
                                     <OutboundLink
                                         analyticsEventLabel={`Clicked on ${sublink.name} -> ${sublink.href}`}
+                                        className={styles.link}
+                                        data-testid={`Nav Item ${sublink.name}`}
                                         href={sublink.href}
                                         // children={<span className={styles.link}>{sublink.name}</span>}
                                         children={<span className={styles.link}>{sublink.name}</span>}
                                         hasIcon={false}
-                                    />
+                                    >
+                                        <span className={styles.link}>{sublink.name}</span>
+                                    </OutboundLink>
                                 )}
                             </li>
                         ))}

--- a/components/Nav/NavListItem/NavListItem.tsx
+++ b/components/Nav/NavListItem/NavListItem.tsx
@@ -3,12 +3,13 @@ import classNames from 'classnames';
 import Link from 'next/link';
 import PlusIcon from 'static/images/icons/plus.svg';
 import MinusIcon from 'static/images/icons/minus.svg';
+import OutboundLink from 'components/OutboundLink/OutboundLink';
 import styles from './NavListItem.module.css';
 
 type SublinkType = {
     name: string;
     href: string;
-    target: string;
+    isExternal: boolean;
 };
 
 export type NavListItemPropsType = {
@@ -21,9 +22,9 @@ export type NavListItemPropsType = {
      */
     href: string;
     /**
-     * Target attribute to be passed to the base anchor element.
+     * Url to be passed to the base anchor element.
      */
-    target: string;
+    isExternal?: boolean;
     /**
      * List of child links containing the `name` and `href`
      */
@@ -34,7 +35,7 @@ export type NavListItemPropsType = {
     icon?: React.ReactElement | null;
 };
 
-function NavListItem({ sublinks, href, name, target, icon = null }: NavListItemPropsType) {
+function NavListItem({ sublinks, href, name, icon = null, isExternal = false }: NavListItemPropsType) {
     const [areSublinksVisible, setSublinksVisible] = useState(false);
 
     const handleKeyDown = (event: React.KeyboardEvent, indexKeyedOn: number) => {
@@ -61,7 +62,7 @@ function NavListItem({ sublinks, href, name, target, icon = null }: NavListItemP
 
     return (
         <li className={styles.NavListItem}>
-            <Link href={href} target={target}>
+            <Link href={href}>
                 <a
                     className={classNames(styles.link, styles.navItemLink)}
                     onMouseEnter={exposeSublinks}
@@ -104,19 +105,26 @@ function NavListItem({ sublinks, href, name, target, icon = null }: NavListItemP
                         {sublinks.map((sublink, index) => (
                             <li className={styles.sublinkListItem} key={sublink.name}>
                                 {/* 😞 next/link fought being mocked, so `prefetch` has test-specific code */}
-                                <Link href={sublink.href} prefetch={process.env.NODE_ENV === 'production'}>
-                                    <a
-                                        className={styles.link}
-                                        key={sublink.name}
-                                        role="link"
-                                        tabIndex={0}
-                                        data-testid={`Nav Item ${sublink.name}`}
-                                        onKeyDown={event => handleKeyDown(event, index)}
-                                        target={sublink.target}
-                                    >
-                                        <span className={styles.linkContent}>{sublink.name}</span>
-                                    </a>
-                                </Link>
+                                {!sublink.isExternal ? (
+                                    <Link href={sublink.href} prefetch={process.env.NODE_ENV === 'production'}>
+                                        <a
+                                            className={styles.link}
+                                            role="link"
+                                            tabIndex={0}
+                                            data-testid={`Nav Item ${sublink.name}`}
+                                            onKeyDown={event => handleKeyDown(event, index)}
+                                        >
+                                            <span className={styles.linkContent}>{sublink.name}</span>
+                                        </a>
+                                    </Link>
+                                ) : (
+                                    <OutboundLink
+                                        analyticsEventLabel={`Clicked on ${sublink.name} -> ${sublink.href}`}
+                                        href={sublink.href}
+                                        children={<span className={styles.link}>{sublink.name}</span>}
+                                        hasIcon={false}
+                                    />
+                                )}
                             </li>
                         ))}
                     </ul>

--- a/components/Nav/NavListItem/NavListItem.tsx
+++ b/components/Nav/NavListItem/NavListItem.tsx
@@ -119,8 +119,6 @@ function NavListItem({ sublinks, href, name, icon = null}: NavListItemPropsType)
                                         className={styles.link}
                                         data-testid={`Nav Item ${sublink.name}`}
                                         href={sublink.href}
-                                        // children={<span className={styles.link}>{sublink.name}</span>}
-                                        children={<span className={styles.link}>{sublink.name}</span>}
                                         hasIcon={false}
                                     >
                                         <span className={styles.link}>{sublink.name}</span>

--- a/components/Nav/NavListItem/NavListItem.tsx
+++ b/components/Nav/NavListItem/NavListItem.tsx
@@ -119,7 +119,7 @@ function NavListItem({ sublinks, href, name, icon = null}: NavListItemPropsType)
                                         className={styles.link}
                                         data-testid={`Nav Item ${sublink.name}`}
                                         href={sublink.href}
-                                        hasIcon={false}
+                                        hasIcon
                                     >
                                         <span className={styles.link}>{sublink.name}</span>
                                     </OutboundLink>

--- a/components/Nav/NavListItem/NavListItem.tsx
+++ b/components/Nav/NavListItem/NavListItem.tsx
@@ -61,7 +61,7 @@ function NavListItem({ sublinks, href, name, target, icon = null }: NavListItemP
 
     return (
         <li className={styles.NavListItem}>
-            <Link href={href}>
+            <Link href={href} target={target}>
                 <a
                     className={classNames(styles.link, styles.navItemLink)}
                     onMouseEnter={exposeSublinks}

--- a/components/Nav/NavListItem/NavListItem.tsx
+++ b/components/Nav/NavListItem/NavListItem.tsx
@@ -4,133 +4,137 @@ import Link from 'next/link';
 import PlusIcon from 'static/images/icons/plus.svg';
 import MinusIcon from 'static/images/icons/minus.svg';
 import OutboundLink from 'components/OutboundLink/OutboundLink';
+import { twMerge } from 'tailwind-merge';
 import styles from './NavListItem.module.css';
 
 interface SublinkType {
-    name: string;
-    href: string;
-    isExternal?: boolean;
-};
-
-export interface NavListItemPropsType {
-    /**
-     * Text used for the label.
-     */
-    name: string;
-    /**
-     * Url to be passed to the base anchor element.
-     */
-    href: string;
-    /**
-     * List of child links containing the `name` and `href`
-     */
-    sublinks?: SublinkType[];
-    /**
-     * Includes an optional icon.
-     */
-    icon?: React.ReactElement | null;
+  name: string;
+  href: string;
+  isExternal?: boolean;
 }
 
-function NavListItem({ sublinks, href, name, icon = null}: NavListItemPropsType) {
-    const [areSublinksVisible, setSublinksVisible] = useState(false);
+export interface NavListItemPropsType {
+  /**
+   * Text used for the label.
+   */
+  name: string;
+  /**
+   * Url to be passed to the base anchor element.
+   */
+  href: string;
+  /**
+   * List of child links containing the `name` and `href`
+   */
+  sublinks?: SublinkType[];
+  /**
+   * Includes an optional icon.
+   */
+  icon?: React.ReactElement | null;
+}
 
-    const handleKeyDown = (event: React.KeyboardEvent, indexKeyedOn: number) => {
-        const lastSublinkIndex = sublinks && sublinks.length - 1;
-        const isLastSublink = indexKeyedOn === lastSublinkIndex;
-        const isFirstSublink = indexKeyedOn === 0;
+function NavListItem({ sublinks, href, name, icon = null }: NavListItemPropsType) {
+  const [areSublinksVisible, setSublinksVisible] = useState(false);
 
-        const didHitTab = event.key === 'Tab';
-        const didTabForward = didHitTab && !event.shiftKey;
-        const didTabBackward = didHitTab && event.shiftKey;
+  const handleKeyDown = (event: React.KeyboardEvent, indexKeyedOn: number) => {
+    const lastSublinkIndex = sublinks && sublinks.length - 1;
+    const isLastSublink = indexKeyedOn === lastSublinkIndex;
+    const isFirstSublink = indexKeyedOn === 0;
 
-        const shouldHideSublinks =
-            (isLastSublink && didTabForward) || (isFirstSublink && didTabBackward);
+    const didHitTab = event.key === 'Tab';
+    const didTabForward = didHitTab && !event.shiftKey;
+    const didTabBackward = didHitTab && event.shiftKey;
 
-        if (shouldHideSublinks) {
-            setSublinksVisible(false);
-        }
-    };
+    const shouldHideSublinks =
+      (isLastSublink && didTabForward) || (isFirstSublink && didTabBackward);
 
-    const hasSublinks = sublinks && sublinks.length > 0;
-    const exposeSublinks = () => setSublinksVisible(true);
-    const hideSublinks = () => setSublinksVisible(false);
-    const invertSublinkVisibility = () => setSublinksVisible(previousState => !previousState);
+    if (shouldHideSublinks) {
+      setSublinksVisible(false);
+    }
+  };
 
-    return (
-        <li className={styles.NavListItem}>
-            <Link href={href}>
-                <a
-                    className={classNames(styles.link, styles.navItemLink)}
-                    onMouseEnter={exposeSublinks}
-                    onMouseLeave={hideSublinks}
-                    role="link"
-                    tabIndex={0}
-                    data-testid={`Nav Item ${name}`}
-                >
-                    <span className={styles.linkContent}>{name}</span>
-                    {icon && icon}
-                </a>
-            </Link>
+  const hasSublinks = sublinks && sublinks.length > 0;
+  const exposeSublinks = () => setSublinksVisible(true);
+  const hideSublinks = () => setSublinksVisible(false);
+  const invertSublinkVisibility = () => setSublinksVisible(previousState => !previousState);
 
-            {hasSublinks && (
-                <>
-                    <button
-                        aria-expanded={areSublinksVisible}
-                        aria-haspopup={hasSublinks}
-                        aria-label="submenu"
-                        className={styles.sublinkToggleButton}
-                        onClick={invertSublinkVisibility}
-                        onMouseEnter={exposeSublinks}
-                        onMouseLeave={hideSublinks}
-                        type="button"
-                    >
-                        {areSublinksVisible ? (
-                            <MinusIcon className={styles.icon} data-testid="minus-icon" />
-                        ) : (
-                            <PlusIcon className={styles.icon} data-testid="plus-icon" />
-                        )}
-                    </button>
+  return (
+    <li className={styles.NavListItem}>
+      <Link href={href}>
+        <a
+          className={classNames(
+            twMerge(styles.link, '[&>svg]:-bottom-2 [&>svg]:right-3'),
+            styles.navItemLink,
+          )}
+          onMouseEnter={exposeSublinks}
+          onMouseLeave={hideSublinks}
+          role="link"
+          tabIndex={0}
+          data-testid={`Nav Item ${name}`}
+        >
+          <span className={styles.linkContent}>{name}</span>
+          {icon && icon}
+        </a>
+      </Link>
 
-                    <ul
-                        className={classNames(styles.sublinksList, {
-                            [styles.invisible]: !areSublinksVisible,
-                        })}
-                        onMouseEnter={exposeSublinks}
-                        onMouseLeave={hideSublinks}
-                    >
-                        {sublinks.map((sublink, index) => (
-                            <li className={styles.sublinkListItem} key={sublink.name}>
-                                {/* 😞 next/link fought being mocked, so `prefetch` has test-specific code */}
-                                {!sublink.isExternal ? (
-                                    <Link href={sublink.href} prefetch={process.env.NODE_ENV === 'production'}>
-                                        <a
-                                            className={styles.link}
-                                            role="link"
-                                            tabIndex={0}
-                                            data-testid={`Nav Item ${sublink.name}`}
-                                            onKeyDown={event => handleKeyDown(event, index)}
-                                        >
-                                            <span className={styles.linkContent}>{sublink.name}</span>
-                                        </a>
-                                    </Link>
-                                ) : (
-                                    <OutboundLink
-                                        analyticsEventLabel={`Clicked on ${sublink.name} -> ${sublink.href}`}
-                                        className={styles.link}
-                                        data-testid={`Nav Item ${sublink.name}`}
-                                        href={sublink.href}
-                                        hasIcon
-                                    >
-                                        <span className={styles.link}>{sublink.name}</span>
-                                    </OutboundLink>
-                                )}
-                            </li>
-                        ))}
-                    </ul>
-                </>
+      {hasSublinks && (
+        <>
+          <button
+            aria-expanded={areSublinksVisible}
+            aria-haspopup={hasSublinks}
+            aria-label="submenu"
+            className={styles.sublinkToggleButton}
+            onClick={invertSublinkVisibility}
+            onMouseEnter={exposeSublinks}
+            onMouseLeave={hideSublinks}
+            type="button"
+          >
+            {areSublinksVisible ? (
+              <MinusIcon className={styles.icon} data-testid="minus-icon" />
+            ) : (
+              <PlusIcon className={styles.icon} data-testid="plus-icon" />
             )}
-        </li>
-    );
+          </button>
+
+          <ul
+            className={classNames(styles.sublinksList, {
+              [styles.invisible]: !areSublinksVisible,
+            })}
+            onMouseEnter={exposeSublinks}
+            onMouseLeave={hideSublinks}
+          >
+            {sublinks.map((sublink, index) => (
+              <li className={styles.sublinkListItem} key={sublink.name}>
+                {/* 😞 next/link fought being mocked, so `prefetch` has test-specific code */}
+                {!sublink.isExternal ? (
+                  <Link href={sublink.href} prefetch={process.env.NODE_ENV === 'production'}>
+                    <a
+                      className={twMerge(styles.link, '[&>svg]:-bottom-2 [&>svg]:right-3')}
+                      role="link"
+                      tabIndex={0}
+                      data-testid={`Nav Item ${sublink.name}`}
+                      onKeyDown={event => handleKeyDown(event, index)}
+                    >
+                      <span className={styles.linkContent}>{sublink.name}</span>
+                    </a>
+                  </Link>
+                ) : (
+                  <OutboundLink
+                    analyticsEventLabel={`Clicked on ${sublink.name} -> ${sublink.href}`}
+                    className={twMerge(styles.link, '[&>svg]:-bottom-2 [&>svg]:right-3')}
+                    data-testid={`Nav Item ${sublink.name}`}
+                    href={sublink.href}
+                    hasIcon
+                  >
+                    <span className={twMerge(styles.link, '[&>svg]:-bottom-2 [&>svg]:right-3')}>{sublink.name}</span>
+                  </OutboundLink>
+                )}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </li>
+  );
 }
 
 export default NavListItem;

--- a/components/Nav/NavListItem/__tests__/__snapshots__/NavListItem.test.tsx.snap
+++ b/components/Nav/NavListItem/__tests__/__snapshots__/NavListItem.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`NavListItem > should render with required props passed 1`] = `
     href="/test"
   >
     <a
-      className="link navItemLink"
+      className="link [&>svg]:-bottom-2 [&>svg]:right-3 navItemLink"
       data-testid="Nav Item Test"
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}

--- a/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
+++ b/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
@@ -126,6 +126,7 @@ exports[`Nav > should render with no props passed 1`] = `
                 },
               ]
             }
+            target="_self"
           />
           <ForwardRef(LoadableComponent)
             href="/services"
@@ -155,6 +156,7 @@ exports[`Nav > should render with no props passed 1`] = `
                 },
               ]
             }
+            target="_self"
           />
           <ForwardRef(LoadableComponent)
             href="/get_involved"
@@ -189,6 +191,7 @@ exports[`Nav > should render with no props passed 1`] = `
                 },
               ]
             }
+            target="_self"
           />
           <li>
             <ForwardRef(LinkComponent)

--- a/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
+++ b/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
@@ -10,57 +10,47 @@ exports[`Nav > should render with no props passed 1`] = `
         {
           "href": "/about",
           "name": "About Us",
-          "target": "_self",
         },
         {
           "href": "/get_involved",
           "name": "Get Involved",
-          "target": "_self",
         },
         {
           "href": "/podcast",
           "name": "Podcast",
-          "target": "_self",
         },
         {
           "href": "/scholarship",
           "name": "Scholarship",
-          "target": "_self",
         },
         {
           "href": "/project_rebuild",
           "name": "Project Rebuild",
-          "target": "_self",
         },
         {
           "href": "/corporate-training",
           "name": "Corporate Training",
-          "target": "_self",
         },
         {
           "href": "/chapters",
           "name": "Chapters",
-          "target": "_self",
         },
         {
           "href": "/sponsorship",
           "name": "Sponsorship",
-          "target": "_self",
         },
         {
           "href": "/swag",
+          "isExternal": true,
           "name": "Merch Store",
-          "target": "_blank",
         },
         {
           "href": "/contact",
           "name": "Contact Us",
-          "target": "_self",
         },
         {
           "href": "/donate",
           "name": "Donate",
-          "target": "_self",
         },
       ]
     }
@@ -107,26 +97,21 @@ exports[`Nav > should render with no props passed 1`] = `
                 {
                   "href": "/team",
                   "name": "Our Team",
-                  "target": "_self",
                 },
                 {
                   "href": "/history",
                   "name": "History",
-                  "target": "_self",
                 },
                 {
                   "href": "/faq",
                   "name": "FAQ",
-                  "target": "_self",
                 },
                 {
                   "href": "/branding",
                   "name": "Branding",
-                  "target": "_self",
                 },
               ]
             }
-            target="_self"
           />
           <ForwardRef(LoadableComponent)
             href="/services"
@@ -137,26 +122,21 @@ exports[`Nav > should render with no props passed 1`] = `
                 {
                   "href": "/podcast",
                   "name": "Podcast",
-                  "target": "_self",
                 },
                 {
                   "href": "/scholarship",
                   "name": "Scholarship",
-                  "target": "_self",
                 },
                 {
                   "href": "/project_rebuild",
                   "name": "Project Rebuild",
-                  "target": "_self",
                 },
                 {
                   "href": "/corporate-training",
                   "name": "Corporate Training",
-                  "target": "_self",
                 },
               ]
             }
-            target="_self"
           />
           <ForwardRef(LoadableComponent)
             href="/get_involved"
@@ -167,31 +147,26 @@ exports[`Nav > should render with no props passed 1`] = `
                 {
                   "href": "/chapters",
                   "name": "Chapters",
-                  "target": "_self",
                 },
                 {
                   "href": "/sponsorship",
                   "name": "Sponsorship",
-                  "target": "_self",
                 },
                 {
                   "href": "/swag",
+                  "isExternal": true,
                   "name": "Merch Store",
-                  "target": "_blank",
                 },
                 {
                   "href": "/contact",
                   "name": "Contact Us",
-                  "target": "_self",
                 },
                 {
                   "href": "/donate",
                   "name": "Donate",
-                  "target": "_self",
                 },
               ]
             }
-            target="_self"
           />
           <li>
             <ForwardRef(LinkComponent)

--- a/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
+++ b/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`Nav > should render with no props passed 1`] = `
           href="/"
         >
           <a
-            className="logoLink link"
+            className="logoLink link [&>svg]:-bottom-2 [&>svg]:right-3"
             onContextMenu={[Function]}
           >
             <ForwardRef
@@ -86,7 +86,7 @@ exports[`Nav > should render with no props passed 1`] = `
           </a>
         </ForwardRef(LinkComponent)>
         <ul
-          className="link"
+          className="link [&>svg]:-bottom-2 [&>svg]:right-3"
         >
           <ForwardRef(LoadableComponent)
             href="/about"
@@ -173,7 +173,7 @@ exports[`Nav > should render with no props passed 1`] = `
               href="/donate"
             >
               <a
-                className="link donateLink"
+                className="link [&>svg]:-bottom-2 [&>svg]:right-3 donateLink"
               >
                 Donate
               </a>

--- a/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
+++ b/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
@@ -10,46 +10,57 @@ exports[`Nav > should render with no props passed 1`] = `
         {
           "href": "/about",
           "name": "About Us",
+          "target": "_self",
         },
         {
           "href": "/get_involved",
           "name": "Get Involved",
+          "target": "_self",
         },
         {
           "href": "/podcast",
           "name": "Podcast",
+          "target": "_self",
         },
         {
           "href": "/scholarship",
           "name": "Scholarship",
+          "target": "_self",
         },
         {
           "href": "/project_rebuild",
           "name": "Project Rebuild",
+          "target": "_self",
         },
         {
           "href": "/corporate-training",
           "name": "Corporate Training",
+          "target": "_self",
         },
         {
           "href": "/chapters",
           "name": "Chapters",
+          "target": "_self",
         },
         {
           "href": "/sponsorship",
           "name": "Sponsorship",
+          "target": "_self",
         },
         {
           "href": "/swag",
           "name": "Merch Store",
+          "target": "_blank",
         },
         {
           "href": "/contact",
           "name": "Contact Us",
+          "target": "_self",
         },
         {
           "href": "/donate",
           "name": "Donate",
+          "target": "_self",
         },
       ]
     }
@@ -96,18 +107,22 @@ exports[`Nav > should render with no props passed 1`] = `
                 {
                   "href": "/team",
                   "name": "Our Team",
+                  "target": "_self",
                 },
                 {
                   "href": "/history",
                   "name": "History",
+                  "target": "_self",
                 },
                 {
                   "href": "/faq",
                   "name": "FAQ",
+                  "target": "_self",
                 },
                 {
                   "href": "/branding",
                   "name": "Branding",
+                  "target": "_self",
                 },
               ]
             }
@@ -121,18 +136,22 @@ exports[`Nav > should render with no props passed 1`] = `
                 {
                   "href": "/podcast",
                   "name": "Podcast",
+                  "target": "_self",
                 },
                 {
                   "href": "/scholarship",
                   "name": "Scholarship",
+                  "target": "_self",
                 },
                 {
                   "href": "/project_rebuild",
                   "name": "Project Rebuild",
+                  "target": "_self",
                 },
                 {
                   "href": "/corporate-training",
                   "name": "Corporate Training",
+                  "target": "_self",
                 },
               ]
             }
@@ -146,22 +165,27 @@ exports[`Nav > should render with no props passed 1`] = `
                 {
                   "href": "/chapters",
                   "name": "Chapters",
+                  "target": "_self",
                 },
                 {
                   "href": "/sponsorship",
                   "name": "Sponsorship",
+                  "target": "_self",
                 },
                 {
                   "href": "/swag",
                   "name": "Merch Store",
+                  "target": "_blank",
                 },
                 {
                   "href": "/contact",
                   "name": "Contact Us",
+                  "target": "_self",
                 },
                 {
                   "href": "/donate",
                   "name": "Donate",
+                  "target": "_self",
                 },
               ]
             }


### PR DESCRIPTION
# Description of changes
This PR fixes a minor routing issue with the Merch Store navigation link where an outside link opens in the current tab instead of a new tab as recommended and as it does in the “Get Involved” page.

# Issue Resolved
Fixes #NA

## Screenshots/GIFs

BEFORE:
![Merch Store](https://github.com/user-attachments/assets/a1ffe842-5c5b-4c2c-8420-bdd2f7cb7f78)

Opens in the current browser tab
![Merch Store 2](https://github.com/user-attachments/assets/f4ad7c8d-54e4-422d-8473-fa48ee6bcb2f)

AFTER:
Opens in a new browser tab
![Merch Store 3](https://github.com/user-attachments/assets/3a3b8aa5-a517-4187-a427-e761a7b92994)