### PR TITLE
1852/remove slack logo

### DIFF
--- a/common/constants/partners.js
+++ b/common/constants/partners.js
@@ -20,12 +20,6 @@ const partners = [
     type: PARTNER_TYPES.KIND,
   },
   {
-    name: 'Slack',
-    logoSource: `${s3}partnerLogos/slack.png`,
-    url: 'https://slack.com/?utm_source=operationcode',
-    type: PARTNER_TYPES.PAID,
-  },
-  {
     name: 'Elyon International',
     logoSource: `${s3}partnerLogos/elyon.png`,
     url: 'https://elyoninternational.com/?utm_source=operationcode',

--- a/components/ReusableSections/SponsorsSection/__tests__/__snapshots__/SponsorsSection.test.tsx.snap
+++ b/components/ReusableSections/SponsorsSection/__tests__/__snapshots__/SponsorsSection.test.tsx.snap
@@ -91,28 +91,6 @@ exports[`SponsorsSection > should render 1`] = `
       >
         <a
           className="inline-flex items-start"
-          href="https://slack.com/?utm_source=operationcode"
-          onClick={[Function]}
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <img
-            alt="Slack logo"
-            src="https://operation-code-assets.s3.us-east-2.amazonaws.com/partnerLogos/slack.png"
-          />
-          <span
-            className="sr-only"
-            data-testid="SCREEN_READER_ONLY"
-          >
-            Opens in new window
-          </span>
-        </a>
-      </div>
-      <div
-        className="text-center w-36"
-      >
-        <a
-          className="inline-flex items-start"
           href="https://threatstack.com/?utm_source=operationcode"
           onClick={[Function]}
           rel="noopener noreferrer"


### PR DESCRIPTION
# Description of changes
I removed the slack logo from the corporate sponsors section. I also updated the snapshot test section to avoid the test failing. 

# Issue Resolved
Fixes #1852 

## Screenshots/GIFs
![image](https://github.com/user-attachments/assets/96e8e375-066c-4f36-9fc9-c4171b455201)

