### PR TITLE
fix: add column gap for android mobile viewport

### DIFF
--- a/styles/get_involved.module.css
+++ b/styles/get_involved.module.css
@@ -4,6 +4,7 @@
   max-width: var(--typicalMaxWidth);
   justify-content: space-evenly;
   flex-wrap: wrap;
+  column-gap: 0.5rem;
 }
 
 :global(#__next) .GetInvolved .ctaContainer > * {

--- a/styles/index.module.css
+++ b/styles/index.module.css
@@ -12,6 +12,7 @@
   max-width: var(--typicalMaxWidth);
   justify-content: space-evenly;
   flex-wrap: wrap;
+  column-gap: 0.5rem;
 }
 
 .Home .ctaContainer > * {


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
This Pull Request will ensure that when android mobile user that has a wide screen as Samsung Galaxy 20 will render the call to action container as a flex column.  
# Issue Resolved
<!-- Keeping the format 'Fixes #{ISSUE_NUMBER}' will automatically resolve the relevant issue when this PR is merged -->
Fixes #1857 

## Screenshots/GIFs
<!-- Please provide a view into the feature/bugfix if possible-->
<img width="1262" alt="image" src="https://github.com/user-attachments/assets/ef7c57ca-5a32-4d56-9ecf-4ee8ead15bd8" />

<img width="422" alt="image" src="https://github.com/user-attachments/assets/a49b3029-9daa-4475-8569-1cdf460bcf28" />




